### PR TITLE
Making SQL query output prettier (re: https://github.com/VizierDB/web-ui/issues/205)

### DIFF
--- a/src/main/scala/org/mimirdb/api/FormattedError.scala
+++ b/src/main/scala/org/mimirdb/api/FormattedError.scala
@@ -1,0 +1,3 @@
+package org.mimirdb.api
+
+case class FormattedError(response: ErrorResponse) extends Exception

--- a/src/main/scala/org/mimirdb/api/MimirAPI.scala
+++ b/src/main/scala/org/mimirdb/api/MimirAPI.scala
@@ -236,6 +236,10 @@ class MimirVizierServlet() extends HttpServlet with LazyLogging {
                     e.getStackTrace.map(_.toString).mkString("\n")
                   ))                  
                 }
+                case FormattedError(errorResponse) => {
+                  logger.debug(s"Internally Formatted Error: ${errorResponse.errorType}")
+                  Json.toJson(errorResponse)
+                }
         
                 case e: Throwable => {
                   logger.error("MimirAPI POST ERROR: ", e)

--- a/src/main/scala/org/mimirdb/api/Response.scala
+++ b/src/main/scala/org/mimirdb/api/Response.scala
@@ -15,6 +15,13 @@ case class ErrorResponse (
 
 object ErrorResponse {
   implicit val format: Format[ErrorResponse] = Json.format
+
+  def apply(error: Throwable, message: String): ErrorResponse = 
+    ErrorResponse(
+      error.getClass.getCanonicalName(),
+      message,
+      error.getStackTrace.map(_.toString).mkString("\n")
+    )
 }
 
 case class LensList (

--- a/src/main/scala/org/mimirdb/util/ErrorUtils.scala
+++ b/src/main/scala/org/mimirdb/util/ErrorUtils.scala
@@ -1,0 +1,49 @@
+package org.mimirdb.util
+
+import org.apache.spark.sql.AnalysisException
+
+object ErrorUtils {
+
+  def prettyAnalysisEror(e: AnalysisException, query: String): String =
+  {
+    val sb = new StringBuilder(e.message+"\n")
+    val queryLines = query.split("\n")
+
+    def normalLine(l: String)    { sb.append(s"    $l\n") }
+    def highlightLine(l: String) { sb.append(s">>> $l\n") }
+
+    sb.append("in\n")
+    e.line match { 
+      case None => queryLines.foreach { normalLine(_) }
+      case Some(lineNo) => {
+        // The line number we get is 1-based.  query's lines are 0-based.
+        if(lineNo > queryLines.size){ 
+          sb.append(s"Query Trace Error: Got Line #$lineNo out of ${queryLines.size}")
+          queryLines.foreach { normalLine(_) }
+        } else {
+          if(lineNo > 2){
+            normalLine(queryLines(lineNo - 3))
+          }
+          if(lineNo > 1){
+            normalLine(queryLines(lineNo - 2))
+          }
+          highlightLine(queryLines(lineNo - 1))
+          for(startPosition <- e.startPosition){
+            sb.append("    ")
+            (0 until (startPosition-2)).foreach { sb.append(' ') }
+            sb.append("^\n")
+          }
+          if(queryLines.size > lineNo + 0){
+            normalLine(queryLines(lineNo))
+          }
+          if(queryLines.size > lineNo + 1){
+            normalLine(queryLines(lineNo+1))
+          }
+        }
+      }
+    }
+
+    sb.toString()
+  }
+
+}


### PR DESCRIPTION
50% of the way to https://github.com/VizierDB/web-ui/issues/205

- Added FormattedError, a way for request handlers to intercept and prettify error output
- Added a pretty-printer for Spark's AnalysisException (using SQL rather than LogicalPlan)
- CreateView now prettyprints errors