### PR TITLE
Pivot lens

### DIFF
--- a/src/main/scala/org/mimirdb/api/APIModel.scala
+++ b/src/main/scala/org/mimirdb/api/APIModel.scala
@@ -1,7 +1,7 @@
 package org.mimirdb.api
 
 import play.api.libs.json._
-import org.apache.spark.sql.types.{ DataType, ArrayType }
+import org.apache.spark.sql.types.{ DataType, ArrayType, StructField, StructType }
 import org.apache.spark.sql.geosparksql.UDT.GeometryUDT
 import org.apache.spark.sql.types.UDTRegistration
 import org.apache.spark.sql.SqlUDTRegistrationProxy
@@ -28,6 +28,12 @@ case class Schema (
 }
 
 object Schema {
+  def apply(schema: StructType): Seq[Schema] =
+    schema.fields.map { Schema(_) }
+
+  def apply(field: StructField): Schema =
+    Schema(field.name, field.dataType)
+
   def apply(name: String, t: String): Schema = 
     Schema(name, decodeType(t))
 

--- a/src/main/scala/org/mimirdb/api/request/CreateLens.scala
+++ b/src/main/scala/org/mimirdb/api/request/CreateLens.scala
@@ -4,7 +4,7 @@ import play.api.libs.json._
 import org.apache.spark.sql.SparkSession
 import com.typesafe.scalalogging.LazyLogging
 
-import org.mimirdb.api.{ Request, Response, MimirAPI }
+import org.mimirdb.api.{ Request, Response, MimirAPI, Schema }
 import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec }
 import org.mimirdb.lenses.{ Lenses, LensConstructor }
 
@@ -59,9 +59,17 @@ object CreateLensRequest
 case class CreateLensResponse (
             /* name of resulting lens */
                   lensName: String,
-                  config: JsValue
+                  config: JsValue,
+                  schema: Seq[Schema]
 ) extends Response
 
 object CreateLensResponse {
   implicit val format: Format[CreateLensResponse] = Json.format
+
+  def apply(output: String, config: JsValue): CreateLensResponse =
+    CreateLensResponse(
+      output, 
+      config, 
+      Schema(MimirAPI.catalog.get(output).schema)
+    )
 }

--- a/src/main/scala/org/mimirdb/lenses/Lenses.scala
+++ b/src/main/scala/org/mimirdb/lenses/Lenses.scala
@@ -10,8 +10,9 @@ object Lenses
     "MISSING_KEY"      -> MissingKeyLens,
     "MERGE_ATTRIBUTES" -> MergeAttributesLens,
     "REPAIR_KEY"       -> RepairKeyLens,
-    "COMMENT"        -> CommentLens,
-    "MISSING_VALUE"  -> MissingValueLens
+    "COMMENT"          -> CommentLens,
+    "MISSING_VALUE"    -> MissingValueLens,
+    "PIVOT"            -> PivotLens
   )
 
   def supportedLenses = implementations.keys.toSeq

--- a/src/main/scala/org/mimirdb/lenses/Lenses.scala
+++ b/src/main/scala/org/mimirdb/lenses/Lenses.scala
@@ -8,7 +8,7 @@ object Lenses
   val implementations = scala.collection.mutable.Map[String, Lens](
     "TYPE_INFERENCE"   -> TypeInferenceLens,
     "MISSING_KEY"      -> MissingKeyLens,
-    "MERGE_ATTRIBUTES" -> MergeAttributesLens,
+    "PICKER"           -> MergeAttributesLens,
     "REPAIR_KEY"       -> RepairKeyLens,
     "COMMENT"          -> CommentLens,
     "MISSING_VALUE"    -> MissingValueLens,

--- a/src/main/scala/org/mimirdb/lenses/implementation/PivotLens.scala
+++ b/src/main/scala/org/mimirdb/lenses/implementation/PivotLens.scala
@@ -8,6 +8,34 @@ import org.mimirdb.caveats.implicits._
 import org.mimirdb.lenses.Lens
 import org.mimirdb.spark.SparkPrimitive.dataTypeFormat
 
+/**
+ * The pivot lens "pivots" a table, modifying rows into columns.
+ *
+ * For example
+ * 
+ *  Year  |  Color  | Price
+ * -------+---------+--------
+ *  2020  |  Blue   |  100k
+ *  2019  |  Blue   |  90k
+ *  2020  |  Red    |  120k
+ *  2019  |  Red    |  130k
+ * 
+ * Pivoting this with 'year' as a target, 'price' as a value, and 'color' as a key produces:
+ * 
+ *  Color | Price_2019 | Price_2020
+ * -------+------------+------------
+ *  Blue  |   90k      |   100k
+ *  Red   |   130k     |   120k
+ *
+ * In summary, every `value` column is split into N copies, where N is the number of distinct
+ * values of the `target` column.  For each distinct value of `key`, the lens will emit one row
+ * containing the corresponding value of the `value` column at the intersection of the `target` and
+ * and `key` values.  If no such rows exist, the cell will be NULL.  If multiple *distinct* values
+ * exist, the cell contents will be arbitrary.
+ *
+ * In either case, if there is not exactly one value that can be placed into a single cell in the
+ * pivot table, the cell will be caveated.
+ */
 case class PivotLensConfig(
   target: String,
   keys: Seq[String],

--- a/src/main/scala/org/mimirdb/lenses/implementation/PivotLens.scala
+++ b/src/main/scala/org/mimirdb/lenses/implementation/PivotLens.scala
@@ -1,0 +1,130 @@
+package org.mimirdb.lenses.implementation
+
+import play.api.libs.json._
+import org.apache.spark.sql.{ DataFrame, Row, Column }
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import org.mimirdb.caveats.implicits._
+import org.mimirdb.lenses.Lens
+import org.mimirdb.spark.SparkPrimitive.dataTypeFormat
+
+case class PivotLensConfig(
+  target: String,
+  keys: Seq[String],
+  values: Seq[String],
+  pivots: Option[Seq[String]]
+)
+{
+  def withPivots(newPivots: Seq[String]) = 
+    PivotLensConfig(target, keys, values, Some(newPivots))
+}
+
+object PivotLensConfig
+{
+  implicit val format:Format[PivotLensConfig] = Json.format
+}
+
+object PivotLens
+  extends Lens
+{
+  val DISTINCT_LIMIT = 50
+
+  def train(input: DataFrame, rawConfig: JsValue): JsValue = 
+  {
+    var config = rawConfig.as[PivotLensConfig]
+
+    if(config.values.isEmpty){
+      throw new IllegalArgumentException(s"Can't pivot without at least one value column specified")
+    }
+
+    val pivots = 
+      input.select( input(config.target).cast(StringType) )
+           .distinct()
+           .take(DISTINCT_LIMIT + 1)
+           .map { _.getString(0) }
+           .toSeq
+
+    if(pivots.size > DISTINCT_LIMIT){
+      throw new IllegalArgumentException(s"Can't pivot on a column with more than $DISTINCT_LIMIT values")
+    }
+    if(pivots.size == 0){
+      throw new IllegalArgumentException(s"Can't pivot on an empty column")
+    }
+
+    Json.toJson(config.withPivots(pivots))
+  }
+
+  def create(input: DataFrame, rawConfig: JsValue, context: String): DataFrame = 
+  {
+    val config = rawConfig.as[PivotLensConfig]
+
+    val safePivots = 
+      config.pivots.toSeq.flatten
+        .map { p => p -> p.replaceAll("[^0-9a-zA-Z_]+", "_") }
+
+    val target = input(config.target)
+
+    def selectedValueColumn(v: String, p: String) = s"first_${v}_${p}"
+    def countColumn(v: String, p: String)         = s"count_${v}_${p}"
+
+    def keyDescriptionParts = 
+      if(config.keys.isEmpty) { Seq() }
+      else {
+        // Emits ' x < ${key1}, ${key2}, ${key3}, ... >'
+        lit(" x < ") +: 
+          config.keys
+                .flatMap { k => Seq(lit(", "), col(k).cast(StringType)) }
+                .drop(1) :+
+          lit(">")
+      }
+
+    val (pivotColumnValues, pivotColumnCounts, caveatedPivotColumns) = 
+      config.values
+        .flatMap { valueName =>  
+          val value = input(valueName)
+          safePivots.map { case (pivot, safePivot) =>
+            val valueIfPivotOtherwiseNull =
+              when(target.cast(StringType) === pivot, value)
+                    .otherwise(lit(null))
+
+            val caveatMessage = concat((Seq[Column](
+                col(countColumn(valueName, safePivot)).cast(StringType),
+                lit(s" alternatives for $valueName x $pivot")
+              ) ++ keyDescriptionParts 
+                :+ lit(s" in $context")
+            ):_*) 
+
+            val caveatCondition = 
+              col(countColumn(valueName, safePivot)) =!= 1
+
+            (
+              first(valueIfPivotOtherwiseNull, ignoreNulls = true)
+                .as(selectedValueColumn(valueName, safePivot)), 
+              countDistinct(valueIfPivotOtherwiseNull)
+                .as(countColumn(valueName, safePivot)), 
+              col(selectedValueColumn(valueName, safePivot))
+                .caveatIf(caveatMessage, caveatCondition)
+                .as(s"${valueName}_${pivot}")
+            )
+          }
+        }
+        .unzip3 
+
+    val intermediateColumns = (pivotColumnValues ++ pivotColumnCounts)
+
+    val pivotedInputWithCounts =
+      if(config.keys.isEmpty){
+        input.agg( intermediateColumns.head, intermediateColumns.tail:_* )
+      } else {
+        input.groupBy( config.keys.map { input(_) }:_*)
+             .agg( intermediateColumns.head, intermediateColumns.tail:_* )
+      }
+
+    val outputColumns =
+      config.keys.map { pivotedInputWithCounts(_) } ++ 
+      caveatedPivotColumns
+
+    return pivotedInputWithCounts.select(outputColumns:_*)
+  }
+
+}

--- a/src/test/scala/org/mimirdb/lenses/PivotLensSpec.scala
+++ b/src/test/scala/org/mimirdb/lenses/PivotLensSpec.scala
@@ -1,0 +1,85 @@
+package org.mimirdb.lenses
+
+import play.api.libs.json._
+import org.specs2.specification.BeforeAll
+import org.specs2.mutable.Specification
+
+import org.apache.spark.sql.DataFrame
+
+import org.mimirdb.api.{ MimirAPI, SharedSparkTestInstance }
+import org.mimirdb.lenses.implementation.PivotLensConfig
+import org.mimirdb.caveats.{ Constants => Caveats }
+import org.mimirdb.caveats.implicits._
+import org.apache.spark.sql.Row
+
+class PivotLensSpec 
+  extends Specification
+  with SharedSparkTestInstance
+  with BeforeAll
+{
+  import spark.implicits._
+
+  def beforeAll = SharedSparkTestInstance.initAPI
+
+  lazy val pivot = Lenses("PIVOT")
+
+  def test[T](
+    target: String = "A",
+    keys: Seq[String] = Seq(),
+    values: Seq[String] = Seq("B"),
+    input: DataFrame = MimirAPI.catalog.get("TEST_R")
+  )(op: DataFrame => T):T = {
+    val config = pivot.train(input, Json.toJson(PivotLensConfig(
+                                          target = target, 
+                                          keys = keys,
+                                          values = values, 
+                                          None
+                                        )))
+    op(pivot.apply(input, config, "TEST"))
+  }
+
+  "Pivot A Table To One Row" >> {
+    test() { df => 
+      df.columns.toSeq must contain(exactly("B_1", "B_2", "B_4"))
+      val result:Seq[Row] = df.stripCaveats.collect().toSeq
+      result must haveSize(1)
+      val row:Row = result.head
+      row.getString(0 /* B_1 */) must beOneOf("2", "3", "4")
+      row.getString(1 /* B_2 */) must beEqualTo("2") // the only other option is NULL
+      row.getString(2 /* B_4 */) must beEqualTo("2")
+    }
+  }
+  "Pivot A Table To Multiple Rows" >> {
+    test(keys = Seq("C")) { df => 
+      df.columns.toSeq must contain(exactly("C", "B_1", "B_2", "B_4"))
+      val result = df.stripCaveats.collect().toSeq
+                      .map { row => row.getString(0) -> (row.getString(1), 
+                                                         row.getString(2), 
+                                                         row.getString(3)) }
+                      .toMap
+      result must haveSize(5)
+      result("1") must beEqualTo( ("3", "2", null) )
+      result("2") must beEqualTo( ("4", null, null) )
+      result("3") must beEqualTo( ("2", null, null) )
+      result("4") must beEqualTo( (null, null, "2") )
+      result(null) must beEqualTo( ("2", null, null) )
+    }
+  }
+  "Caveat Multi-Valued Pivots" >> {
+    test() { df => 
+      val annotations:Row = 
+        df.trackCaveats
+          .collect()
+          .head
+          .getAs[Row](Caveats.ANNOTATION_ATTRIBUTE)
+          .getAs[Row](Caveats.ATTRIBUTE_FIELD)
+
+      // B_1 has three possible values
+      annotations.getAs[Boolean]("B_1") must beTrue
+      // B_2 has two possible values, but one is null
+      annotations.getAs[Boolean]("B_2") must beFalse
+      // B_4 has exactly one possible value
+      annotations.getAs[Boolean]("B_4") must beFalse
+    }
+  }
+}


### PR DESCRIPTION
This pull request is the Mimir-API side implementation of https://github.com/VizierDB/web-ui/issues/101

The pivot lens "pivots" a table, modifying rows into columns.
For example

 Year  |  Color  | Price
-------+---------+--------
 2020  |  Blue   |  100k
 2019  |  Blue   |  90k
 2020  |  Red    |  120k
 2019  |  Red    |  130k

Pivoting this with 'year' as a target, 'price' as a value, and 'color' as a key produces:

 Color | Price_2019 | Price_2020
-------+------------+------------
 Blue  |   90k      |   100k
 Red   |   130k     |   120k
 
In summary, every `value` column is split into N copies, where N is the number of distinct
values of the `target` column.  For each distinct value of `key`, the lens will emit one row
containing the corresponding value of the `value` column at the intersection of the `target` and
and `key` values.  If no such rows exist, the cell will be NULL.  If multiple *distinct* values
exist, the cell contents will be arbitrary.
In either case, if there is not exactly one value that can be placed into a single cell in the
pivot table, the cell will be caveated.