### PR TITLE
Load mimir-caveat UDFs to support caveating from SQL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ excludeDependencies ++= Seq(
 // Custom Dependencies
 libraryDependencies ++= Seq(
   // Mimir
-  "org.mimirdb"                   %% "mimir-caveats"             % "0.1",
+  "org.mimirdb"                   %% "mimir-caveats"             % "0.2-SNAPSHOT",
   // "org.mimirdb"                   %% "mimir-vizual"              % "0.1-SNAPSHOT",
 
   // API
@@ -59,7 +59,7 @@ libraryDependencies ++= Seq(
   "org.eclipse.jetty"             %   "jetty-servlets"           % "9.4.10.v20180503",
   "org.eclipse.jetty"             %   "jetty-util"               % "9.4.10.v20180503",
   "org.eclipse.jetty"             %   "jetty-webapp"             % "9.4.10.v20180503",
-  
+
   //Data Source Support
   //"com.amazonaws"               %   "aws-java-sdk-bundle"      % "1.11.375",
   //"org.apache.hadoop"           %   "hadoop-aws"               % "3.2.0",
@@ -68,11 +68,11 @@ libraryDependencies ++= Seq(
   "org.apache.hadoop"             %   "hadoop-aws"               % "2.8.3"    excludeAll( ExclusionRule("com.fasterxml.jackson.core"), ExclusionRule(organization ="com.amazonaws")),
   "com.amazonaws"                 %   "aws-java-sdk-core"        % "1.11.199" excludeAll( ExclusionRule("com.fasterxml.jackson.core")),
   "com.amazonaws"                 %   "aws-java-sdk-s3"          % "1.11.199" excludeAll( ExclusionRule("com.fasterxml.jackson.core")),
-  
+
   //Scala eval support
   "org.scala-lang"                %   "scala-reflect"            % scalaVersion.value,
   "org.scala-lang"                %   "scala-compiler"           % scalaVersion.value,
-  
+
   //GIS Support
   "org.datasyslab"                %  "geospark"                  % "1.4.0" excludeAll(ExclusionRule(organization ="com.amazonaws")),
   "org.datasyslab"                %  "geospark-sql_3.0"          % "1.4.0" excludeAll(ExclusionRule(organization ="com.amazonaws"), ExclusionRule(organization ="org.datasyslab", name="sernetcdf")),
@@ -80,18 +80,18 @@ libraryDependencies ++= Seq(
 
   //Other data importers
   "com.databricks"                %% "spark-xml"                 % "0.9.0",
-  
+
   //Google Sheets Datasource
   "info.mimirdb"                  %% "spark-google-spreadsheets" % "0.6.4",
-  
+
   //excel data loading
   "com.crealytics"                %%  "spark-excel"              % "0.13.3+17-b51cc0ac+20200722-1201-SNAPSHOT"
-  
+
 )
 
 ////// Generate a Coursier Bootstrap Jar
 // See https://get-coursier.io/docs
-// 
+//
 import scala.sys.process.{Process, ProcessLogger}
 lazy val bootstrap = taskKey[Unit]("Generate Bootstrap Jar")
 bootstrap := {
@@ -107,7 +107,7 @@ bootstrap := {
       "-o", coursier_bin,
       coursier_url
     )) ! logger match {
-      case 0 => 
+      case 0 =>
       case n => sys.error(s"Could not download Coursier")
     }
     Process(List(
@@ -118,7 +118,7 @@ bootstrap := {
 
   println("Coursier available.  Generating Repository List")
 
-  val resolverArgs = resolvers.value.map { 
+  val resolverArgs = resolvers.value.map {
     case r: MavenRepository => Seq("-r", r.root)
   }.flatten
 
@@ -129,7 +129,7 @@ bootstrap := {
   for(resolver <- resolverArgs){
     println("  "+resolver)
   }
-  
+
   println("Generating Mimir-API Server binary")
   Process(List(
     coursier_bin,
@@ -140,14 +140,14 @@ bootstrap := {
     "-r", "central",
     "-M", "mimir.MimirVizier"
   )++resolverArgs) ! logger match {
-      case 0 => 
+      case 0 =>
       case n => sys.error(s"Bootstrap failed")
   }
 }
 
 
 ////// Publishing Metadata //////
-// use `sbt publish make-pom` to generate 
+// use `sbt publish make-pom` to generate
 // a publishable jar artifact and its POM metadata
 
 publishMavenStyle := true
@@ -166,7 +166,7 @@ pomExtra := <url>http://mimirdb.info</url>
   </scm>
 
 /////// Publishing Options ////////
-// use `sbt publish` to update the package in 
+// use `sbt publish` to update the package in
 // your own local ivy cache
 
 publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ excludeDependencies ++= Seq(
 // Custom Dependencies
 libraryDependencies ++= Seq(
   // Mimir
-  "org.mimirdb"                   %% "mimir-caveats"             % "0.2-SNAPSHOT",
+  "org.mimirdb"                   %% "mimir-caveats"             % "0.2",
   // "org.mimirdb"                   %% "mimir-vizual"              % "0.1-SNAPSHOT",
 
   // API

--- a/src/main/scala/org/mimirdb/rowids/AnnotateWithSequenceNumber.scala
+++ b/src/main/scala/org/mimirdb/rowids/AnnotateWithSequenceNumber.scala
@@ -6,6 +6,7 @@ import org.apache.spark.sql.catalyst.AliasIdentifier
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -36,14 +37,14 @@ object AnnotateWithSequenceNumber
 
   def apply(
     df: DataFrame,
-    attribute: String = ATTRIBUTE, 
+    attribute: String = ATTRIBUTE,
     offset:Long = 0
   ): DataFrame = {
     if(df.schema.fieldNames.contains(ATTRIBUTE)){
       return df
     }
 
-    val annotatedPlan = 
+    val annotatedPlan =
       apply(
         df.queryExecution.analyzed,
         df.queryExecution.sparkSession,
@@ -58,9 +59,9 @@ object AnnotateWithSequenceNumber
   }
 
   def apply(
-    plan: LogicalPlan, 
-    session: SparkSession, 
-    attribute: Attribute, 
+    plan: LogicalPlan,
+    session: SparkSession,
+    attribute: Attribute,
     offset:Long
   ): LogicalPlan =
   {
@@ -72,7 +73,7 @@ object AnnotateWithSequenceNumber
     def ResolvedAlias(expr: Expression, attr: Attribute): NamedExpression =
       Alias(expr, attr.name)(attr.exprId)
 
-    val planWithPartitionedIdentifierAttributes = 
+    val planWithPartitionedIdentifierAttributes =
       Project(
         plan.output ++ Seq(
           ResolvedAlias(SparkPartitionID(), PARTITION_ID),
@@ -81,11 +82,11 @@ object AnnotateWithSequenceNumber
         plan
       )
 
-    /** 
-     * id offset for input rows for a given session (Seq of Integers) 
-     * 
+    /**
+     * id offset for input rows for a given session (Seq of Integers)
+     *
      * For each partition, determine the difference between the identifier
-     * assigned to elements of the partition, and the true ROWID. This 
+     * assigned to elements of the partition, and the true ROWID. This
      * offset value is computed as:
      *   [true id of the first element of the partition]
      *     - [first assigned id of the partition]
@@ -93,21 +94,21 @@ object AnnotateWithSequenceNumber
      * The true ID is computed by a windowed aggregate over the counts
      * of all partitions with earlier identifiers. The window includes
      * the count of the current partition, so that gets subtracted off.
-     * 
+     *
      * The first assigned ID is simply obtained by the FIRST aggregate.
      *   [[ Oliver: Might MIN be safer? ]]
      *
-     * Calling this function pre-computes and caches the resulting 
-     * partition-id -> offset map.  Because the partition-ids are 
-     * sequentially assigned, starting from zero, we can represent the 
+     * Calling this function pre-computes and caches the resulting
+     * partition-id -> offset map.  Because the partition-ids are
+     * sequentially assigned, starting from zero, we can represent the
      * Map more efficiently as a Sequence.
-     * 
-     * The map might change every session, so the return value of this 
+     *
+     * The map might change every session, so the return value of this
      * function should not be cached between sessions.
      */
-    val planToComputeFirstPerPartitionIdentifier = 
+    val planToComputeFirstPerPartitionIdentifier =
       Project(Seq(
-        PARTITION_ID, 
+        PARTITION_ID,
         ResolvedAlias(
           Add(
             Subtract(
@@ -117,26 +118,26 @@ object AnnotateWithSequenceNumber
                     Sum(COUNT_ATTR),
                     Complete,false),
                   WindowSpecDefinition(
-                    Seq(), 
-                    Seq(SortOrder(PARTITION_ID, Ascending)), 
+                    Seq(),
+                    Seq(SortOrder(PARTITION_ID, Ascending)),
                     UnspecifiedFrame)
-                ), 
+                ),
                 COUNT_ATTR),
               INTERNAL_ID
             ),
             Literal(offset)
           ),COUNT_ATTR)
-        ), 
+        ),
         Sort(
-          Seq(SortOrder(PARTITION_ID, Ascending)), 
-          true,   
+          Seq(SortOrder(PARTITION_ID, Ascending)),
+          true,
           Aggregate(
             Seq(PARTITION_ID),
             Seq(
-              PARTITION_ID, 
+              PARTITION_ID,
               ResolvedAlias(AggregateExpression(
                   Count(Seq(Literal(1))),Complete,false
-                ), COUNT_ATTR), 
+                ), COUNT_ATTR),
               ResolvedAlias(AggregateExpression(
                   First(INTERNAL_ID,Literal(false)),Complete,false
                 ),INTERNAL_ID)
@@ -144,8 +145,8 @@ object AnnotateWithSequenceNumber
           planWithPartitionedIdentifierAttributes)
         )
       )
-    
-    val firstPerPartitionIdentifierMap = 
+
+    val firstPerPartitionIdentifierMap =
       new DataFrame(
         session,
         planToComputeFirstPerPartitionIdentifier,
@@ -160,14 +161,15 @@ object AnnotateWithSequenceNumber
 
     def lookupFirstIdentifier(partition: Expression) =
       ScalaUDF(
-        (partitionId:Int) => firstPerPartitionIdentifierMap(partitionId),
-        LongType,
-        Seq(partition),
-        Seq(false),
-        Seq(IntegerType),
-        Some("FIRST_IDENTIFIER_FOR_PARTITION"), /*name hint*/
-        true, /*nullable*/
-        true, /*deterministic*/
+        function = (partitionId:Int) => firstPerPartitionIdentifierMap(partitionId),
+        dataType = LongType,
+        children = Seq(partition),
+        inputEncoders = Seq(Some(ExpressionEncoder[Int])),
+//        Seq(false),
+//        inputEncoders = Seq(IntegerType),
+        udfName = Some("FIRST_IDENTIFIER_FOR_PARTITION"), /*name hint*/
+        nullable = true, /*nullable*/
+        udfDeterministic = true /*deterministic*/
       )
 
     Project(

--- a/src/main/scala/org/mimirdb/rowids/WithSemiStableIdentifier.scala
+++ b/src/main/scala/org/mimirdb/rowids/WithSemiStableIdentifier.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
 object WithSemiStableIdentifier
 {
@@ -22,7 +23,7 @@ object WithSemiStableIdentifier
     def ResolvedAlias(expr: Expression, attr: Attribute): NamedExpression =
       Alias(expr, attr.name)(attr.exprId)
 
-    val planWithPartitionedIdentifierAttributes = 
+    val planWithPartitionedIdentifierAttributes =
       Project(
         plan.output ++ Seq(
           ResolvedAlias(SparkPartitionID(), PARTITION_ID),
@@ -31,11 +32,11 @@ object WithSemiStableIdentifier
         plan
       )
 
-    /** 
-     * id offset for input rows for a given session (Seq of Integers) 
-     * 
+    /**
+     * id offset for input rows for a given session (Seq of Integers)
+     *
      * For each partition, determine the difference between the identifier
-     * assigned to elements of the partition, and the true ROWID. This 
+     * assigned to elements of the partition, and the true ROWID. This
      * offset value is computed as:
      *   [true id of the first element of the partition]
      *     - [first assigned id of the partition]
@@ -43,21 +44,21 @@ object WithSemiStableIdentifier
      * The true ID is computed by a windowed aggregate over the counts
      * of all partitions with earlier identifiers. The window includes
      * the count of the current partition, so that gets subtracted off.
-     * 
+     *
      * The first assigned ID is simply obtained by the FIRST aggregate.
      *   [[ Oliver: Might MIN be safer? ]]
      *
-     * Calling this function pre-computes and caches the resulting 
-     * partition-id -> offset map.  Because the partition-ids are 
-     * sequentially assigned, starting from zero, we can represent the 
+     * Calling this function pre-computes and caches the resulting
+     * partition-id -> offset map.  Because the partition-ids are
+     * sequentially assigned, starting from zero, we can represent the
      * Map more efficiently as a Sequence.
-     * 
-     * The map might change every session, so the return value of this 
+     *
+     * The map might change every session, so the return value of this
      * function should not be cached between sessions.
      */
-    val planToComputeFirstPerPartitionIdentifier = 
+    val planToComputeFirstPerPartitionIdentifier =
       Project(Seq(
-        PARTITION_ID, 
+        PARTITION_ID,
         ResolvedAlias(
           Add(
             Subtract(
@@ -67,26 +68,26 @@ object WithSemiStableIdentifier
                     Sum(COUNT_ATTR),
                     Complete,false),
                   WindowSpecDefinition(
-                    Seq(), 
-                    Seq(SortOrder(PARTITION_ID, Ascending)), 
+                    Seq(),
+                    Seq(SortOrder(PARTITION_ID, Ascending)),
                     UnspecifiedFrame)
-                ), 
+                ),
                 COUNT_ATTR),
               INTERNAL_ID
             ),
             Literal(offset)
           ),COUNT_ATTR)
-        ), 
+        ),
         Sort(
-          Seq(SortOrder(PARTITION_ID, Ascending)), 
-          true,   
+          Seq(SortOrder(PARTITION_ID, Ascending)),
+          true,
           Aggregate(
             Seq(PARTITION_ID),
             Seq(
-              PARTITION_ID, 
+              PARTITION_ID,
               ResolvedAlias(AggregateExpression(
                   Count(Seq(Literal(1))),Complete,false
-                ), COUNT_ATTR), 
+                ), COUNT_ATTR),
               ResolvedAlias(AggregateExpression(
                   First(INTERNAL_ID,Literal(false)),Complete,false
                 ),INTERNAL_ID)
@@ -94,8 +95,8 @@ object WithSemiStableIdentifier
           planWithPartitionedIdentifierAttributes)
         )
       )
-    
-    val firstPerPartitionIdentifierMap = 
+
+    val firstPerPartitionIdentifierMap =
       new DataFrame(
         session,
         planToComputeFirstPerPartitionIdentifier,
@@ -113,11 +114,11 @@ object WithSemiStableIdentifier
         (partitionId:Int) => firstPerPartitionIdentifierMap(partitionId),
         LongType,
         Seq(partition),
-        Seq(false),
-        Seq(IntegerType),
-        Some("FIRST_IDENTIFIER_FOR_PARTITION"), /*name hint*/
-        true, /*nullable*/
-        true, /*deterministic*/
+        //Seq(false),
+        inputEncoders = Seq(Some(ExpressionEncoder[Int])),
+        udfName = Some("FIRST_IDENTIFIER_FOR_PARTITION"), /*name hint*/
+        nullable = true, /*nullable*/
+        udfDeterministic = true /*deterministic*/
       )
 
     Project(

--- a/src/main/scala/org/mimirdb/spark/GetViewDependencies.scala
+++ b/src/main/scala/org/mimirdb/spark/GetViewDependencies.scala
@@ -1,7 +1,7 @@
 package org.mimirdb.spark
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.catalyst.plans.logical.{ LogicalPlan, View } 
+import org.apache.spark.sql.catalyst.plans.logical.{ LogicalPlan, View }
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
 
@@ -11,9 +11,9 @@ object GetViewDependencies
     apply(df.queryExecution.analyzed)
 
   def apply(plan: LogicalPlan): Set[String] =
-    plan.collect { 
+    plan.collect {
       // case View(table, _, _) => table.identifier.unquotedString
       case UnresolvedRelation(table) => table.last:String
-      case SubqueryAlias(identifier, _) => identifier.identifier
+      case SubqueryAlias(identifier, _) => identifier.name // identifier.identifier
     }.toSet
 }

--- a/src/main/scala/org/mimirdb/spark/InitSpark.scala
+++ b/src/main/scala/org/mimirdb/spark/InitSpark.scala
@@ -6,6 +6,7 @@ import org.apache.spark.serializer.KryoSerializer
 import org.datasyslab.geosparkviz.core.Serde.GeoSparkVizKryoRegistrator
 import org.datasyslab.geosparksql.utils.GeoSparkSQLRegistrator
 import org.datasyslab.geosparkviz.sql.utils.GeoSparkVizRegistrator
+import org.mimirdb.caveats.Caveats
 
 object InitSpark
 {
@@ -27,6 +28,7 @@ object InitSpark
     GeoSparkSQLRegistrator.registerAll(sparkSession)
     GeoSparkVizRegistrator.registerAll(sparkSession)
     System.setProperty("geospark.global.charset", "utf8")
+    Caveats.registerAllUDFs(sparkSession)
   }
-  
+
 }

--- a/src/test/scala/org/mimirdb/lenses/PivotLensSpec.scala
+++ b/src/test/scala/org/mimirdb/lenses/PivotLensSpec.scala
@@ -52,10 +52,18 @@ class PivotLensSpec
   "Pivot A Table To Multiple Rows" >> {
     test(keys = Seq("C")) { df => 
       df.columns.toSeq must contain(exactly("C", "B_1", "B_2", "B_4"))
+
+      val pos = (
+        df.columns.indexOf("C"),
+        df.columns.indexOf("B_1"),
+        df.columns.indexOf("B_2"),
+        df.columns.indexOf("B_4"),
+      )
+
       val result = df.stripCaveats.collect().toSeq
-                      .map { row => row.getString(0) -> (row.getString(1), 
-                                                         row.getString(2), 
-                                                         row.getString(3)) }
+                      .map { row => row.getString(pos._1) -> (row.getString(pos._2), 
+                                                              row.getString(pos._3), 
+                                                              row.getString(pos._4)) }
                       .toMap
       result must haveSize(5)
       result("1") must beEqualTo( ("3", "2", null) )


### PR DESCRIPTION
Bumped up `mimir-caveat` dependency to version `0.2-SNAPSHOT`, changed UDFs to confirm to modification in Scala's `ScalaUDF` class and called function in `InitSpark` to register caveat UDFs for SQL usage.
----

#