### PR TITLE
Avoid duplicate column names in CSV files

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -22,6 +22,9 @@
 
   <!--+++++++++++++++++++++++  Lenses  +++++++++++++++++++++++++-->
   <logger name="org.mimirdb.lenses.implementation.CommentLens$"            level="INFO" />
+
+  <!--+++++++++++++++++++++++  Data Load  +++++++++++++++++++++++++-->
+  <logger name="org.mimirdb.data.LoadConstructor"                          level="INFO" />
     
   <root level="ERROR">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
When asked to load a CSV file with duplicate column names, Mimir now appends a _# to the column name.