### PR TITLE
Adding Table Size and Garbage Collection endpoints

### DIFF
--- a/src/main/scala/org/mimirdb/api/MimirAPI.scala
+++ b/src/main/scala/org/mimirdb/api/MimirAPI.scala
@@ -304,14 +304,15 @@ class MimirVizierServlet() extends HttpServlet with LazyLogging {
             case "/query/table"          => processJson[QueryTableRequest](req, output)
             case "/schema"               => processJson[SchemaForQueryRequest](req, output)
             case "/tableInfo"            => processJson[SchemaForTableRequest](req, output)
+            case "/garbageCollect"       => process(GarbageCollectRequest(), output)
             case _                       => fourOhFour(req, output)
           }
         case _                           => fourOhFour(req, output)
       }
     }
     
-    val HEAD = "\\/([^\\/]+)/(.*)".r
-    val TAIL = "([^\\/]+)".r
+    val HEAD = "\\/([^\\/]+)(/.*)".r
+    val TAIL = "/([^\\/]+)".r
 
     override def doPut(req: HttpServletRequest, output: HttpServletResponse)
     {
@@ -331,12 +332,14 @@ class MimirVizierServlet() extends HttpServlet with LazyLogging {
       req.getPathInfo match {
         case PREFIX(route) => 
           route match {
-            case "/lens"                    => LensList(Lenses.supportedLenses).write(output)
-            case HEAD("blob", TAIL(id))     => process(GetBlobRequest(id), output)
-            case HEAD("tableInfo", TAIL(id))=> process(SchemaForTableRequest(id), output)
-            case _                          => fourOhFour(req, output)
+            case "/lens"                                    => LensList(Lenses.supportedLenses).write(output)
+            case HEAD("blob", TAIL(id))                     => process(GetBlobRequest(id), output)
+            case HEAD("tableInfo", TAIL(id))                => process(SchemaForTableRequest(id), output)
+            case HEAD("tableInfo", HEAD(id, TAIL("schema")))=> process(SchemaForTableRequest(id), output)
+            case HEAD("tableInfo", HEAD(id, TAIL("size")))  => process(SizeOfTableRequest(id), output)
+            case _                                          => fourOhFour(req, output)
           }
-        case _                              => fourOhFour(req, output)
+        case _                                              => fourOhFour(req, output)
       }
     }
 

--- a/src/main/scala/org/mimirdb/api/Response.scala
+++ b/src/main/scala/org/mimirdb/api/Response.scala
@@ -72,6 +72,13 @@ object ErrorResponse {
     )
 }
 
+case class SuccessResponse(message: String) extends JsonResponse[SuccessResponse] {}
+
+object SuccessResponse
+{
+  implicit val format: Format[SuccessResponse] = Json.format
+}
+
 
 case class LensList (
     lensTypes: Seq[String]

--- a/src/main/scala/org/mimirdb/api/request/GarbageCollect.scala
+++ b/src/main/scala/org/mimirdb/api/request/GarbageCollect.scala
@@ -1,0 +1,12 @@
+package org.mimirdb.api.request
+
+import org.mimirdb.api.{ Request, Response, MimirAPI }
+import org.mimirdb.api.SuccessResponse
+
+case class GarbageCollectRequest() extends Request
+{
+  def handle = {
+    MimirAPI.catalog.populateSpark(forgetInvalidTables = true)
+    SuccessResponse(s"Garbage Collection Successful: ${MimirAPI.catalog.cache.size} tables still loaded.")
+  }
+}

--- a/src/main/scala/org/mimirdb/api/request/Query.scala
+++ b/src/main/scala/org/mimirdb/api/request/Query.scala
@@ -19,6 +19,7 @@ import org.mimirdb.util.TimerUtils
 import com.typesafe.scalalogging.LazyLogging
 import org.mimirdb.lenses.AnnotateImplicitHeuristics
 import org.mimirdb.rowids.AnnotateWithSequenceNumber
+import com.google.common.collect.Table
 
 case class QueryMimirRequest (
             /* input for query */
@@ -47,6 +48,8 @@ case class QueryMimirRequest (
 object QueryMimirRequest {
   implicit val format: Format[QueryMimirRequest] = Json.format
 }
+
+/***************************************************************************************/
 
 case class QueryTableRequest (
             /* input for query */
@@ -87,6 +90,7 @@ object QueryTableRequest {
   implicit val format: Format[QueryTableRequest] = Json.format
 }
 
+/***************************************************************************************/
 
 case class SchemaForQueryRequest (
             /* query string to get schema for - sql */
@@ -98,6 +102,8 @@ case class SchemaForQueryRequest (
 object SchemaForQueryRequest {
   implicit val format: Format[SchemaForQueryRequest] = Json.format
 }
+
+/***************************************************************************************/
 
 case class SchemaForTableRequest (
             /* table name */
@@ -112,6 +118,23 @@ case class SchemaForTableRequest (
 object SchemaForTableRequest {
   implicit val format: Format[SchemaForTableRequest] = Json.format
 }
+
+/***************************************************************************************/
+
+case class SizeOfTableRequest (
+            /* table name */
+                  table: String
+) extends Request {
+  def handle = TableSize(
+    MimirAPI.catalog.get(table).count()
+  )
+}
+
+object SizeOfTableRequest {
+  implicit val format: Format[SizeOfTableRequest] = Json.format
+}
+
+/***************************************************************************************/
 
 case class DataContainer (
                   schema: Seq[StructField],
@@ -169,6 +192,8 @@ object DataContainer {
   )
 }
 
+/***************************************************************************************/
+
 case class SchemaList (
     schema: Seq[StructField],
     properties: Map[String, JsValue]
@@ -178,7 +203,21 @@ object SchemaList {
   implicit val format: Format[SchemaList] = Json.format
 }
 
+/***************************************************************************************/
+
+case class TableSize (
+    size: Long,
+) extends JsonResponse[TableSize]
+
+object TableSize {
+  implicit val format: Format[TableSize] = Json.format
+}
+
+/***************************************************************************************/
+
 class ResultTooBig extends Exception("The datsaet is too big to copy.  Try a sample or a LIMIT query instead.")
+
+/***************************************************************************************/
 
 object Query
   extends LazyLogging

--- a/src/test/scala/org/mimirdb/api/request/QuerySpec.scala
+++ b/src/test/scala/org/mimirdb/api/request/QuerySpec.scala
@@ -232,6 +232,10 @@ class QuerySpec
         result.data must beEqualTo(data.drop(2).take(2))
       }
     }
+
+    "Get Table Sizes" >> { 
+      SizeOfTableRequest("TEST_R").handle.size must beEqualTo(7)
+    }
   }
 
 }


### PR DESCRIPTION
(wip for https://github.com/VizierDB/web-ui/issues/265)

- Adding GET .../tableInfo/[tableName]/schema endpoin (synonym for .../tableInfo/[tableName])  This is just for consistency
- Adding GET .../tableInfo/[tableName]/size endpoint (returns the size of the table / COUNT)   The mimir-side fix for https://github.com/VizierDB/web-ui/issues/265
- Adding POST .../garbageCollect (kicks out tables that are no longer valid; no arguments)   This is desperately needed.  In a long-running deployment of Mimir, tons of cruft builds up (also related to https://github.com/VizierDB/web-ui/issues/265 , but this is only a temporary fix)