### PR TITLE
Injected spark sql

### DIFF
--- a/src/main/scala/org/mimirdb/api/request/CreateSample.scala
+++ b/src/main/scala/org/mimirdb/api/request/CreateSample.scala
@@ -159,8 +159,8 @@ case class CreateSampleRequest (
                   properties: Option[Map[String,JsValue]]
 ) extends Request with DataFrameConstructor {
 
-  def construct(spark: SparkSession, context: Map[String,DataFrame]): DataFrame =
-    samplingMode.apply(context(source), seed.getOrElse { new Random().nextLong })
+  def construct(spark: SparkSession, context: Map[String, () => DataFrame]): DataFrame =
+    samplingMode.apply(context(source)(), seed.getOrElse { new Random().nextLong })
 
   def handle = {
     if(!MimirAPI.catalog.exists(source)){

--- a/src/main/scala/org/mimirdb/api/request/CreateView.scala
+++ b/src/main/scala/org/mimirdb/api/request/CreateView.scala
@@ -38,7 +38,11 @@ case class CreateViewRequest (
 
   def construct(spark: SparkSession, context: Map[String, () => DataFrame]): DataFrame =
   {
-    var df = InjectedSparkSQL(spark)(query, context, allowMappedTablesOnly = true)
+    var df = InjectedSparkSQL(spark)(
+                  query, 
+                  input.mapValues { context(_) },
+                  allowMappedTablesOnly = true
+              )
     df = AnnotateImplicitHeuristics(df)
     return df 
   }

--- a/src/main/scala/org/mimirdb/api/request/Explain.scala
+++ b/src/main/scala/org/mimirdb/api/request/Explain.scala
@@ -10,6 +10,7 @@ import org.mimirdb.caveats.{ Caveat, CaveatSet }
 import org.mimirdb.api.CaveatFormat._
 import org.mimirdb.caveats.implicits._
 import org.mimirdb.rowids.AnnotateWithRowIds
+import org.mimirdb.spark.InjectedSparkSQL
 
 case class ExplainCellRequest (
             /* query to explain */
@@ -94,8 +95,7 @@ object Explain
     spark: SparkSession = MimirAPI.sparkSession
   ): Seq[CaveatSet] = 
   {
-    MimirAPI.catalog.populateSpark()
-    var df = spark.sql(query)
+    var df = InjectedSparkSQL(spark)(query, MimirAPI.catalog.allTableConstructors)
     val selectedCols = 
       Option(cols).getOrElse { df.schema.fieldNames.toSeq }.toSet
     if(rows != null){

--- a/src/main/scala/org/mimirdb/api/request/Query.scala
+++ b/src/main/scala/org/mimirdb/api/request/Query.scala
@@ -19,6 +19,7 @@ import org.mimirdb.util.TimerUtils
 import com.typesafe.scalalogging.LazyLogging
 import org.mimirdb.lenses.AnnotateImplicitHeuristics
 import org.mimirdb.rowids.AnnotateWithSequenceNumber
+import org.mimirdb.spark.InjectedSparkSQL
 
 case class QueryMimirRequest (
             /* input for query */
@@ -193,9 +194,8 @@ object Query
     sparkSession: SparkSession = MimirAPI.sparkSession
   ): DataContainer = 
   {
-    MimirAPI.catalog.populateSpark()
     apply(
-      sparkSession.sql(query), 
+      InjectedSparkSQL(sparkSession)(query, MimirAPI.catalog.allTableConstructors),
       includeCaveats = includeCaveats, 
       limit = limit,
       computedProperties = Map.empty
@@ -311,8 +311,8 @@ object Query
     query: String,
     sparkSession: SparkSession = MimirAPI.sparkSession
   ): Seq[StructField] = { 
-    MimirAPI.catalog.populateSpark()
-    Schema(sparkSession.sql(query))
+    val df = InjectedSparkSQL(sparkSession)(query, MimirAPI.catalog.allTableConstructors)
+    Schema(df)
   }
 
 }

--- a/src/main/scala/org/mimirdb/data/DataFrameConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/DataFrameConstructor.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.{ SparkSession, DataFrame }
 
 trait DataFrameConstructor 
 {
-  def construct(spark: SparkSession, context: Map[String,DataFrame]): DataFrame
+  def construct(spark: SparkSession, context: Map[String,() => DataFrame]): DataFrame
 
   // Assume a default companion object with a format
   def deserializer = getClass.getName + "$"

--- a/src/main/scala/org/mimirdb/data/InlineConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/InlineConstructor.scala
@@ -16,7 +16,7 @@ case class InlineConstructor(
 {
   def construct(
     spark: SparkSession, 
-    context: Map[String, DataFrame] = Map()
+    context: Map[String, () => DataFrame] = Map()
   ): DataFrame =
   {
     val types = schema.map { _.dataType }

--- a/src/main/scala/org/mimirdb/data/LoadConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/LoadConstructor.scala
@@ -30,7 +30,7 @@ case class LoadConstructor(
 {
   def construct(
     spark: SparkSession, 
-    context: Map[String, DataFrame] = Map()
+    context: Map[String, () => DataFrame] = Map()
   ): DataFrame =
   {
     var df =

--- a/src/main/scala/org/mimirdb/data/RangeConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/RangeConstructor.scala
@@ -15,7 +15,7 @@ case class RangeConstructor(
 {
   def construct(
     spark: SparkSession, 
-    context: Map[String, DataFrame] = Map()
+    context: Map[String, () => DataFrame] = Map()
   ): DataFrame =
   {
     spark.range(start, end, step).toDF

--- a/src/main/scala/org/mimirdb/lenses/LensConstructor.scala
+++ b/src/main/scala/org/mimirdb/lenses/LensConstructor.scala
@@ -11,8 +11,8 @@ case class LensConstructor(
   context: String
 ) extends DataFrameConstructor
 {
-  def construct(spark: SparkSession, evalContext: Map[String, DataFrame]): DataFrame =
-    Lenses(name.toLowerCase()).create(evalContext(input), config, context)
+  def construct(spark: SparkSession, evalContext: Map[String, () => DataFrame]): DataFrame =
+    Lenses(name.toLowerCase()).create(evalContext(input)(), config, context)
 }
 
 object LensConstructor 

--- a/src/main/scala/org/mimirdb/spark/InjectedSparkSQL.scala
+++ b/src/main/scala/org/mimirdb/spark/InjectedSparkSQL.scala
@@ -1,0 +1,111 @@
+package org.mimirdb.spark
+
+import com.typesafe.scalalogging.LazyLogging
+
+import org.apache.spark.sql.{ SparkSession, DataFrame, Row, Dataset }
+import org.apache.spark.sql.catalyst.{ QueryPlanningTracker, AliasIdentifier }
+import org.apache.spark.sql.catalyst.plans.logical.{ LogicalPlan, SubqueryAlias, View }
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.execution.QueryExecution
+
+import org.mimirdb.data.Catalog
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.mimirdb.api.MimirAPI
+import org.apache.spark.sql.AnalysisException
+import org.mimirdb.api.{ FormattedError, ErrorResponse }
+import org.apache.spark.sql.catalyst.catalog.{ CatalogTable, CatalogStorageFormat, CatalogTableType }
+import org.apache.spark.sql.catalyst.TableIdentifier
+
+
+/**
+ * Utilities for running Spark SQL queries with a post-processing step injected between
+ * the parser and the analysis phase.
+ */
+case class InjectedSparkSQL(spark: SparkSession)
+  extends LazyLogging
+{
+  /**
+   * Run the specified query with supplemental views
+   *
+   * @param  sqlText                 The query to run
+   * @param  tableMappings           The (case-insensitive) views to substitute in the query
+   * @param  allowMappedTablesOnly   If true, only allow tables that appear in tableMappings (default: false)
+   * @return                         A DataFrame (analogous to SparkSession.sql)
+   */
+  def apply(
+    sqlText: String, 
+    tableMappings: Map[String,() => DataFrame] = Map(), 
+    allowMappedTablesOnly: Boolean = false
+  ): DataFrame =
+  {
+    // ~= Spark's SparkSession.sql()
+    val tracker = new QueryPlanningTracker
+    var logicalPlan = spark.sessionState.sqlParser.parsePlan(sqlText)
+    logger.trace(logicalPlan.toString())
+    
+    // The magic happens here.  We rewrite the query to inject our own 
+    // table rewrites
+    logicalPlan = rewrite(
+      logicalPlan, 
+      tableMappings.map { case (k, v) => k.toLowerCase() -> v }.toMap,// make source names case insensitive
+      allowMappedTablesOnly
+    )
+
+    logger.trace(logicalPlan.toString())
+    // ~= Spark's Dataset.ofRows()
+    val qe = new QueryExecution(spark, logicalPlan)
+    logger.trace(qe.analyzed.toString())
+
+
+    qe.assertAnalyzed()
+    return new Dataset[Row](spark, qe.analyzed, RowEncoder(qe.analyzed.schema))
+  }
+
+  /**
+   * Rewrite the specified logical plan with a set of supplemental views
+   *
+   * @param  sqlText                 The query to run
+   * @param  tableMappings           The (case-insensitive) views to substitute in the query
+   * @param  allowMappedTablesOnly   If true, only allow tables that appear in tableMappings (default: false)
+   * @return                         A DataFrame (analogous to SparkSession.sql)
+   */
+  def rewrite(
+    plan: LogicalPlan, 
+    tableMappings: Map[String, () => DataFrame] = Map(), 
+    allowMappedTablesOnly: Boolean = false
+  ): LogicalPlan =
+  {
+    logger.debug(s"Rewriting...\n$plan")
+    plan.transformUp { 
+      case original @ UnresolvedRelation(Seq(identifier)) => 
+        tableMappings.get(identifier.toLowerCase()) match {
+          // If we only allow mapped tables, throw a nice user-friendly error
+          case None if allowMappedTablesOnly => 
+            throw new FormattedError(
+              ErrorResponse(
+                "org.apache.spark.sql.AnalysisException",
+                s"Unknown table $identifier (Available tables: ${tableMappings.keys.mkString(", ")})",
+                ""
+              )
+            )
+
+          // If we allow any tables, pass through and let spark catch any problems
+          case None => original
+
+          // Finally, if we have a mapping, use it!
+          case Some(constructor) => 
+            // It's *critical* that we use the *analyzed* version of the query here.  Otherwise,
+            // we end up with multiple copies of the same name floating around which makes
+            // spark righteously upset.
+            val child = constructor().queryExecution.analyzed
+
+            // Wrap the child in a SubqueryAlias to allow the SQL query to refer to the stored 
+            // table by its aliased name.
+            SubqueryAlias(
+              AliasIdentifier(identifier.toLowerCase()),
+              child
+            )
+        }
+    }
+  }
+}

--- a/src/main/scala/org/mimirdb/util/ErrorUtils.scala
+++ b/src/main/scala/org/mimirdb/util/ErrorUtils.scala
@@ -4,16 +4,24 @@ import org.apache.spark.sql.AnalysisException
 
 object ErrorUtils {
 
-  def prettyAnalysisEror(e: AnalysisException, query: String): String =
-  {
-    val sb = new StringBuilder(e.message+"\n")
-    val queryLines = query.split("\n")
+  def prettyAnalysisError(e: AnalysisException, query: String): String =
+    prettySQLError(e.message, query, e.line, e.startPosition.getOrElse(0))
 
+  def prettySQLError(
+    message: String, 
+    query: String, 
+    targetLine: Option[Int] = None, 
+    startPosition: Int = 0
+  ): String = {
+    val sb = new StringBuilder(message+"\n")
+    sb.append("in\n")
+    
     def normalLine(l: String)    { sb.append(s"    $l\n") }
     def highlightLine(l: String) { sb.append(s">>> $l\n") }
-
-    sb.append("in\n")
-    e.line match { 
+    
+    val queryLines = query.split("\n")
+    
+    targetLine match { 
       case None => queryLines.foreach { normalLine(_) }
       case Some(lineNo) => {
         // The line number we get is 1-based.  query's lines are 0-based.
@@ -28,11 +36,10 @@ object ErrorUtils {
             normalLine(queryLines(lineNo - 2))
           }
           highlightLine(queryLines(lineNo - 1))
-          for(startPosition <- e.startPosition){
-            sb.append("    ")
-            (0 until (startPosition-2)).foreach { sb.append(' ') }
-            sb.append("^\n")
-          }
+          sb.append("    ")
+          (0 until (startPosition-2)).foreach { sb.append(' ') }
+          sb.append("^\n")
+
           if(queryLines.size > lineNo + 0){
             normalLine(queryLines(lineNo))
           }

--- a/src/main/scala/org/mimirdb/vizual/VizualScriptConstructor.scala
+++ b/src/main/scala/org/mimirdb/vizual/VizualScriptConstructor.scala
@@ -10,8 +10,8 @@ case class VizualScriptConstructor(
 )
   extends DataFrameConstructor
 {
-  def construct(spark: SparkSession, context: Map[String,DataFrame]): DataFrame =
-    ExecOnSpark(context(input), script)
+  def construct(spark: SparkSession, context: Map[String, () => DataFrame]): DataFrame =
+    ExecOnSpark(context(input)(), script)
 }
 
 object VizualScriptConstructor 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -24,6 +24,8 @@
   <logger name="org.mimirdb.lenses.AnnotateImplicitHeuristics$" level="ERROR" />
   <logger name="org.mimirdb.lenses.CaveatedCast$"               level="ERROR" />
 
+  <!--++++++++++++++++++++++++  Spark  ++++++++++++++++++++++++++-->
+  <logger name="org.mimirdb.spark.InjectedSparkSQL"             level="ERROR" />
   
   <root level="ERROR">
     <appender-ref ref="STDOUT" />

--- a/src/test/scala/org/mimirdb/api/SharedSparkTestInstance.scala
+++ b/src/test/scala/org/mimirdb/api/SharedSparkTestInstance.scala
@@ -70,7 +70,6 @@ object SharedSparkTestInstance
           Seq(TestCaseGeocoder),
           MimirAPI.catalog
         )
-        MimirAPI.catalog.populateSpark()
       }
     }
   }

--- a/src/test/scala/org/mimirdb/api/request/CreateViewSpec.scala
+++ b/src/test/scala/org/mimirdb/api/request/CreateViewSpec.scala
@@ -7,6 +7,7 @@ import org.specs2.specification.BeforeAll
 import org.mimirdb.api.SharedSparkTestInstance
 import org.mimirdb.api.MimirAPI
 import org.mimirdb.spark.GetViewDependencies
+import org.mimirdb.spark.InjectedSparkSQL
 
 
 class CreateViewSpec 
@@ -19,7 +20,7 @@ class CreateViewSpec
 
   "Check that spark represents views in the expected way" >> 
   {
-    val query = spark.sql("SELECT * FROM TEST_R, GEO")
+    val query = InjectedSparkSQL(spark)("SELECT * FROM TEST_R, GEO", MimirAPI.catalog.allTableConstructors)
     // query.explain(true)
     GetViewDependencies(query).map { _.toLowerCase() } must contain(
       "test_r", "geo"

--- a/src/test/scala/org/mimirdb/spark/SparkParserInjectionSpec.scala
+++ b/src/test/scala/org/mimirdb/spark/SparkParserInjectionSpec.scala
@@ -1,0 +1,32 @@
+package org.mimirdb.spark
+
+import org.specs2.specification.BeforeAll
+import org.specs2.mutable.Specification
+
+import org.mimirdb.api.{ SharedSparkTestInstance, MimirAPI }
+import org.mimirdb.api.FormattedError
+
+
+class SparkParserInjectionSpec 
+  extends Specification
+  with SharedSparkTestInstance
+  with BeforeAll
+{
+  def beforeAll: Unit = SharedSparkTestInstance.initAPI
+
+  val inject = InjectedSparkSQL(spark)
+
+  "Inject names into the parser" >> {
+    val df = inject(
+      "SELECT * FROM INJECTED_TABLE", 
+      Map("INJECTED_TABLE" -> { () => MimirAPI.catalog.get("TEST_R") })
+    )
+
+    df.count() must be equalTo(7l)
+  }
+
+  "Disallow non-mapped names if requested" >> {
+    inject("SELECT * FROM TEST_R", allowMappedTablesOnly = true) must throwA[FormattedError]
+  }
+
+}


### PR DESCRIPTION
(closes https://github.com/VizierDB/web-ui/issues/265)
(closes https://github.com/UBOdin/mimir-api/issues/17)

Until this commit, API was using DataFrame.createOrReplaceView to get SparkContext.sql to
properly recognize view names (via Catalog.populateSpark).  This is a *HUGE* hack:
- It's not threadsafe: Two concurrent queries with overlapping table names may accidentally get
  each other's tables.
- It pollutes the Spark namespace: It becomes possible to reference a table in a query before
  the query was created, or worse, an arbitrary table from another notebook.
- It's slow: Since we don't know which tables will be referenced, we need to populate the ENTIRE
  namespace.  This gets progressively slower every time we insert a new table, and gets really slow
  when the source datafile for each of those tables go away without us noticing... and then we need to keep trying to (slowly) preload on every query.

This commit introduces a new utility class: InjectedSparkSQL.

With SparkSession.sql:
```
 plan = parse(query)
 return new DataFrame(analyze(plan))
```

With InjectedSparkSQL:
```
 plan = parse(query)
 plan = injectViews(plan, viewMap)
 return new DataFrame(analyze(plan))
```

In short, InjectedSparkSQL takes a map of view constructors and injects them into the logical plan
after parsing, but before analysis has a chance to realize that Spark knows nothing about the
referenced views.  Spark can then happily analyze the query and all else is good.

The following additional changes were made:
  - InjectedSparkSQL replaces Catalog.populateSpark everywhere **except** the CodeEval request.  It
    *should* be possible to do something there as well, but will require users to use the vizier
    object to access spark dataframes.
  - Catalog.populateSpark now prints a warning message
  - Changed the API of DataFrameConstructor to provide context as a map from name to *constructor*
    (previously, this was just a map from name to dataframe).  Making this map's contents lazy like
    so should address the performance issue: We don't need to preload *all* tables, just the ones
    that actually get used.