### PR TITLE
Preliminary implementation of a data profiler hidden behind a feature flag

### DIFF
--- a/Profiler.txt
+++ b/Profiler.txt
@@ -1,0 +1,123 @@
+For Each Column:
+  - column:
+      id: 
+      name: 
+      type:
+  - values:
+    For each Bucket:
+    - name: 
+      count:
+  - binSize:
+  - stats:
+      count:
+      distinctValueCount
+      sum
+      mean
+      stdDev
+      min
+      max
+
+
+-----
+
+
+[
+  {
+    "column": {
+      "id": 0,
+      "name": "TKEY",
+      "type": "short"
+    },
+    "values": [
+      {
+        "name": "1",
+        "count": 2
+      },
+      {
+        "name": "2",
+        "count": 2
+      },
+      {
+        "name": "3",
+        "count": 2
+      },
+      {
+        "name": "5",
+        "count": 2
+      }
+    ],
+    "binSize": -1,
+    "stats": {
+      "count": 8,
+      "distinctValueCount": 4,
+      "sum": 0,
+      "mean": 0,
+      "stdDev": 78,
+      "min": null,
+      "max": null
+    }
+  },
+  {
+    "column": {
+      "id": 1,
+      "name": "A",
+      "type": "float"
+    },
+    "values": [
+      {
+        "name": "4",
+        "count": 6
+      },
+      {
+        "name": "6.400000095367432",
+        "count": 2
+      }
+    ],
+    "binSize": -1,
+    "stats": {
+      "count": 8,
+      "distinctValueCount": 2,
+      "sum": 0,
+      "mean": 0,
+      "stdDev": 177.92000244140627,
+      "min": null,
+      "max": null
+    }
+  },
+  {
+    "column": {
+      "id": 2,
+      "name": "B",
+      "type": "string"
+    },
+    "values": [
+      {
+        "name": "5.0",
+        "count": 1
+      },
+      {
+        "name": "3.5",
+        "count": 1
+      },
+      {
+        "name": "2.0",
+        "count": 1
+      },
+      {
+        "name": "4.0",
+        "count": 1
+      }
+    ],
+    "binSize": -1,
+    "stats": {
+      "count": 8,
+      "distinctValueCount": 4,
+      "sum": 0,
+      "mean": 0,
+      "stdDev": 57.25,
+      "min": null,
+      "max": null
+    }
+  }
+]
+

--- a/src/main/scala/org/mimirdb/api/Config.scala
+++ b/src/main/scala/org/mimirdb/api/Config.scala
@@ -30,4 +30,5 @@ class MimirConfig(arguments: Seq[String]) extends ScallopConf(arguments)
     descr = "spark master.",
     default = Some("local")
   )
+  val experimental = opt[List[String]]("X", default = Some(List[String]()))
 }

--- a/src/main/scala/org/mimirdb/api/MimirAPI.scala
+++ b/src/main/scala/org/mimirdb/api/MimirAPI.scala
@@ -44,6 +44,7 @@ import org.mimirdb.util.JsonUtils.stringifyJsonParseErrors
 import org.apache.spark.sql.AnalysisException
 import org.mimirdb.data.MetadataBackend
 import org.mimirdb.blobs.BlobStore
+import org.mimirdb.util.ExperimentalOptions
 
 //import org.apache.spark.ui.FixWebUi
 
@@ -66,6 +67,9 @@ object MimirAPI extends LazyLogging {
     logger.debug("debug is enabled")
     conf = new MimirConfig(args);
     conf.verify
+
+    // Prepare Experiments
+    ExperimentalOptions.enable(conf.experimental())
 
     // Initialize Spark
     sparkSession = InitSpark.local

--- a/src/main/scala/org/mimirdb/data/DataFrameConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/DataFrameConstructor.scala
@@ -2,12 +2,31 @@ package org.mimirdb.data
 
 import play.api.libs.json.{ JsValue, Format }
 import org.apache.spark.sql.{ SparkSession, DataFrame } 
+import org.mimirdb.profiler.DataProfiler
 
+/**
+ * A generic view definition for the Mimir Catalog.  Used by Catalog.put and related operations
+ */
 trait DataFrameConstructor 
 {
+  /**
+   * Construct the DataFrame represented by this Constructor
+   * 
+   * @param spark     The Spark session in the context of which to create the DataFrame
+   * @param context   Lazy constructors for dependent dataframes, organized by name.  
+   * @return          The DataFrame
+   *
+   * When `Catalog.put` is called, one of its parameters is a list of dependencies.  Only dependent
+   * tables will be present in the context.
+   */
   def construct(spark: SparkSession, context: Map[String,() => DataFrame]): DataFrame
 
-  // Assume a default companion object with a format
+  /**
+   * The companion object including a deserialization method.
+   * @return          The class of companion object extending the DataFrameConstructorCodec trait
+   *
+   * By default, this assumes a companion object of the same name as the base class.
+   */
   def deserializer = getClass.getName + "$"
 }
 

--- a/src/main/scala/org/mimirdb/profiler/AggregateStats.scala
+++ b/src/main/scala/org/mimirdb/profiler/AggregateStats.scala
@@ -1,0 +1,99 @@
+package org.mimirdb.profiler
+
+import play.api.libs.json.{ Json, JsValue, Writes }
+import org.apache.spark.sql.{ DataFrame, Column, Row }
+import org.apache.spark.sql.types.{ DataType, StructField, NumericType, FloatType }
+import org.apache.spark.sql.functions._
+
+import DataProfiler.{ DatasetProperty, ColumnProperty, ColumnName } 
+
+
+object AggregateStats extends ProfilerModule
+{
+
+  def ExtractAs[T](implicit encode: Writes[T]): (Row, Int) => JsValue = 
+    { (row, i) => Json.toJson(row.getAs[T](i)) }
+
+  def AnyTypeStat[T](f: Column => Column)
+                         (implicit encode: Writes[T]):
+                  (Column, DataType) => Option[(Column, (Row, Int) => JsValue)] = 
+    { (col, t) => Some( (f(col), ExtractAs[T]) ) }
+
+  def NumericStat[T](f: Column => Column)
+                (implicit encode: Writes[T]):
+                  (Column, DataType) => Option[(Column, (Row, Int) => JsValue)] =
+    {
+      case (col, t:DataType) if t.isInstanceOf[NumericType] => 
+        Some( (f(col), ExtractAs[T]) )
+      case _ => None
+    }
+
+  val tableAggregates = 
+    Map[String, (Column, (Row, Int) => JsValue)](
+      "count" -> (count("*"), ExtractAs[Long])
+    )
+
+  val columnAggregates = 
+    Map[String, (Column, DataType) => Option[(Column, (Row, Int) => JsValue)]](
+      "count"                -> AnyTypeStat[Long] { count(_) },
+      "distinctValueCount"   -> AnyTypeStat[Long] { approx_count_distinct(_) },
+      "sum"                  -> NumericStat[Float] { sum(_).cast(FloatType) },
+      "mean"                 -> NumericStat[Float] { avg(_).cast(FloatType) },
+      "stdDev"               -> NumericStat[Float] { stddev(_).cast(FloatType) },
+      "min"                  -> NumericStat[Float] { min(_).cast(FloatType) },
+      "max"                  -> NumericStat[Float] { max(_).cast(FloatType) }
+    )
+
+  val depends = (Set(), Set("column"))
+  val provides = (
+    tableAggregates.keySet,
+    columnAggregates.keySet
+  )
+
+  def apply(df: DataFrame, inputs: (Map[DatasetProperty, JsValue], Map[ColumnName, Map[ColumnProperty, JsValue]])): 
+    (Map[DatasetProperty,JsValue], Map[ColumnName,Map[ColumnProperty,JsValue]]) = 
+  {
+    val schema = df.schema.fields
+
+    // Fields: 
+    //  - Target Column (None for Dataset)
+    //  - Aggregate Expression
+    //  - Property Name
+    //  - Data Extractor
+    //  - Position
+    val queries: Seq[(Option[String], Column, String, Row => JsValue, Int)] = 
+      (
+        tableAggregates.map { 
+          case (property, (aggregate, extractor)) => 
+            (None, aggregate, property, extractor)
+        } ++ schema.flatMap { case StructField(column, t, _, _) =>
+          columnAggregates.flatMap {
+            case (property, constructor) =>
+              constructor(df(column), t).map { 
+                case (aggregate, extractor) => 
+                  (Some(column), aggregate, property, extractor)
+              }
+          }
+        }
+      ).zipWithIndex.map { 
+          case ((column, aggregate, property, extractor), index) =>
+            (column, aggregate, property, extractor(_, index), index)
+      }.toSeq
+
+    val statsRow = 
+      df.select(queries.map { q => q._2.as(s"stat_${q._5}") }:_*)
+        .take(1)
+        .head
+
+    val (datasetQueries, columnQueries) = 
+      queries.partition { _._1.isEmpty }
+
+
+    return (
+      datasetQueries.map { q => q._3 -> q._4(statsRow) }.toMap,
+      columnQueries.map { q => (q._1.get, q._3, q._4(statsRow)) }
+                   .groupBy { _._1 }
+                   .mapValues { _.map { property => property._2 -> property._3 }.toMap }
+    )
+  }
+}

--- a/src/main/scala/org/mimirdb/profiler/DataProfiler.scala
+++ b/src/main/scala/org/mimirdb/profiler/DataProfiler.scala
@@ -1,0 +1,46 @@
+package org.mimirdb.profiler
+
+import org.apache.spark.sql.DataFrame
+import play.api.libs.json.{ Json, JsValue }
+
+object DataProfiler
+{
+  type DatasetProperty = String
+  type ColumnProperty = String
+  type ColumnName = String
+
+  val profilers = Seq[ProfilerModule](
+    StaticStats,
+    AggregateStats
+  )
+
+  def apply(df: DataFrame): Map[String, JsValue] = 
+  {
+    val (datasetProperties, columnProperties) = 
+      profilers.foldLeft(
+        (
+          Map[DatasetProperty, JsValue](), 
+          df.columns.map { _ -> Map[ColumnProperty, JsValue]() }.toMap
+        )
+      ) { case (accum, profiler) => 
+        val newFields = profiler(df, accum)
+        (
+          accum._1 ++ newFields._1,
+          df.columns.map { col => 
+            col -> (
+              accum._2.getOrElse(col, { Map[ColumnProperty, JsValue]() })
+                ++ newFields._2.getOrElse(col, { Map[ColumnProperty, JsValue]() })
+            )
+          }.toMap
+        )
+      }
+    return datasetProperties + (
+      "columns" -> 
+        Json.toJson(
+          df.columns
+            .map { columnProperties.getOrElse(_, { Map[String, JsValue]()} ) }
+            .toSeq
+        )
+    )
+  }
+}

--- a/src/main/scala/org/mimirdb/profiler/ProfilerModule.scala
+++ b/src/main/scala/org/mimirdb/profiler/ProfilerModule.scala
@@ -1,0 +1,16 @@
+package org.mimirdb.profiler
+
+import org.apache.spark.sql.DataFrame
+import play.api.libs.json.JsValue
+
+import DataProfiler.{ DatasetProperty, ColumnProperty, ColumnName } 
+
+trait ProfilerModule
+{
+
+  val depends:  (Set[DatasetProperty], Set[ColumnProperty])
+  val provides: (Set[DatasetProperty], Set[ColumnProperty])
+
+  def apply(df: DataFrame, inputs: (Map[DatasetProperty, JsValue], Map[ColumnName, Map[ColumnProperty, JsValue]])): 
+    (Map[DatasetProperty, JsValue], Map[ColumnName, Map[ColumnProperty, JsValue]])
+}

--- a/src/main/scala/org/mimirdb/profiler/StaticStats.scala
+++ b/src/main/scala/org/mimirdb/profiler/StaticStats.scala
@@ -1,0 +1,35 @@
+package org.mimirdb.profiler
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.StructField
+import play.api.libs.json.{ Json, JsValue, JsNumber, JsString }
+import DataProfiler.{ DatasetProperty, ColumnProperty, ColumnName } 
+
+object StaticStats extends ProfilerModule
+{
+  val depends  = (Set(), Set())
+  val provides = (Set(), Set("column"))
+
+  def apply(df: DataFrame, inputs: (Map[DatasetProperty, JsValue], Map[ColumnName, Map[ColumnProperty, JsValue]])): 
+    (Map[DatasetProperty, JsValue], Map[ColumnName, Map[ColumnProperty, JsValue]]) =
+  {
+    (
+      Map(),
+      df.schema
+        .fields
+        .zipWithIndex
+        .map { case (StructField(name, t, _, _), idx) => 
+          name -> 
+            Map(
+              "column" -> 
+                Json.obj(
+                  "id" -> JsNumber(idx),
+                  "name" -> JsString(name),
+                  "type" -> JsString(t.typeName)
+                )
+            )
+        }.toMap
+    )
+
+  }
+}

--- a/src/main/scala/org/mimirdb/util/ExperimentalOptions.scala
+++ b/src/main/scala/org/mimirdb/util/ExperimentalOptions.scala
@@ -1,0 +1,75 @@
+package org.mimirdb.util
+
+import scala.collection.GenTraversableOnce
+
+/**
+ * Utilities for globally enabling or disabling experimental
+ * configuration options.  Usually configuration should happen
+ * either in a test case, or in the startup process of whatever
+ * UI is being used (e.g., Mimir.scala for command line opts)
+ *
+ * Within the code, use either isEnabled, or ifEnabled to 
+ * branch based on the specific experimental option.
+ */
+object ExperimentalOptions {
+
+  var enabled:Set[String] = 
+    System.getenv("MIMIR_EXPERIMENTS") match {
+      case null => Set.empty
+      case "" => Set.empty
+      case x => x.split(",").toSet
+    }
+
+  /**
+   * Enable one experimental option
+   */
+  def enable(option: String): Unit = 
+    enabled = enabled + option
+  /**
+   * Disable one experimental option
+   */
+  def disable(option: String): Unit = 
+    enabled = enabled - option
+
+  /**
+   * Enable a set of options
+   */
+  def enable(options: GenTraversableOnce[String]): Unit =
+    { enabled = (enabled ++ options) }
+  /**
+   * Disable a set of options
+   */
+  def disable(options: GenTraversableOnce[String]): Unit =
+    { enabled = (enabled -- options) }
+
+  /**
+   * For unit tests ONLY: Execute a block of code with options enabled
+   */
+  def withEnabled[A](options: GenTraversableOnce[String], cmd: (() => A)): A =
+  {
+    val optionStack = enabled
+    enable(options)
+    val ret = cmd()
+    enabled = optionStack
+    ret
+  }
+
+  /**
+   * Test whether an option is enabled
+   */
+  def isEnabled(option: String): Boolean =
+    enabled contains option
+
+  /**
+   * Execute code iff an option is enabled
+   */
+  def ifEnabled[A](opt: String, cmd: (() => A)): Option[A] =
+    { if(enabled contains opt){ Some(cmd()) } else { None } }
+
+  /**
+   * Branch depending on whether an option is enabled
+   */
+  def ifEnabled[A](opt: String, thenCmd: (() => A), elseCmd: () => A): A =
+    { if(enabled contains opt){ thenCmd() } else { elseCmd() }  }
+
+}

--- a/src/main/scala/org/mimirdb/util/TimerUtils.scala
+++ b/src/main/scala/org/mimirdb/util/TimerUtils.scala
@@ -4,6 +4,19 @@ trait TimerUtils
 {
   protected def logger: com.typesafe.scalalogging.Logger
 
+  def time = TimerUtils.time _
+
+  def logTime[F](
+    descriptor: String, 
+    context: String = "",
+    log:(String => Unit) = logger.debug(_)
+  )(anonFunc: => F): F = 
+    TimerUtils.logTime(descriptor, context, log)(anonFunc)
+
+}
+
+object TimerUtils
+{
   def time[F](anonFunc: => F): (F, Long) = 
   {  
     val tStart = System.nanoTime()
@@ -15,7 +28,7 @@ trait TimerUtils
   def logTime[F](
     descriptor: String, 
     context: String = "",
-    log:(String => Unit) = logger.debug(_)
+    log:(String => Unit) = println(_)
   )(anonFunc: => F): F = 
   {
     val (anonFuncRet, nanoTime) = time(anonFunc)

--- a/src/test/scala/org/mimirdb/data/CatalogSpec.scala
+++ b/src/test/scala/org/mimirdb/data/CatalogSpec.scala
@@ -4,11 +4,16 @@ import org.specs2.mutable.Specification
 import org.mimirdb.api.SharedSparkTestInstance
 import org.mimirdb.api.request.DataContainer
 import org.mimirdb.api.request.Query
+import play.api.libs.json.JsValue
+import org.specs2.specification.BeforeAll
 
 class CatalogSpec 
   extends Specification
   with SharedSparkTestInstance
+  with BeforeAll
 {
+
+  def beforeAll = SharedSparkTestInstance.initAPI
 
   lazy val catalog = new Catalog("target/catalog.db", spark)
 
@@ -16,42 +21,63 @@ class CatalogSpec
               (op: DataContainer => T): T = 
     op(Query(query, includeUncertainty, sparkSession = spark))
   
-  "The Catalog" >> {
+  "Serialize and Deserialize Constructors" >>
+  {
+    val table = "TEMP"
+    val original = catalog.put(table,
+      LoadConstructor(
+        "test_data/r.csv",
+        "csv",
+        Map(), 
+      ),
+      Set[String]()
+    ).collect().map { _.toSeq }
 
-    "Serialize and Deserialize Constructors" >>
-    {
-      val table = "TEMP"
-      val original = catalog.put(table,
-        LoadConstructor(
-          "test_data/r.csv",
-          "csv",
-          Map(), 
-        ),
-        Set[String]()
-      ).collect().map { _.toSeq }
+    catalog.flush(table)
+    val reloaded = catalog.get(table)
+      .collect().map { _.toSeq }
 
-      catalog.flush(table)
-      val reloaded = catalog.get(table)
-        .collect().map { _.toSeq }
+    reloaded must be equalTo(original)
+  }
+  
+  "Query a catalog table" >> 
+  {
+    val table = "QUERY_R"
+    catalog.put(table,
+      LoadConstructor(
+        "test_data/r.csv",
+        "csv",
+        Map(),
+      ),
+      Set[String]()
+    )
+    query("SELECT COUNT(*) FROM QUERY_R") { result =>
+      result.data.map { _(0) } must beEqualTo(Seq(7))
+    } 
+  }
 
-      reloaded must be equalTo(original)
-    }
-    
-    "Query a catalog table" >> 
-    {
-      val table = "QUERY_R"
-      catalog.put(table,
-        LoadConstructor(
-          "test_data/r.csv",
-          "csv",
-          Map(),
-        ),
-        Set[String]()
-      )
-      query("SELECT COUNT(*) FROM QUERY_R") { result =>
-        result.data.map { _(0) } must beEqualTo(Seq(7))
-      } 
-    }
+  "Profile a catalog table" >>
+  {
+    val table = "profile_r"
+    catalog.put(table,
+      LoadConstructor(
+        "test_data/r.csv",
+        "csv",
+        Map("header" -> "true"),
+      ),
+      Set[String]()
+    )
+    catalog.profile(table)
+    val properties = catalog.getProperties(table)
+    properties("count").as[Int] must beEqualTo(7)
+    properties("columns")
+              .as[Seq[Map[String,JsValue]]]
+              .apply(0)
+              .apply("column")
+              .as[Map[String,JsValue]]
+              .apply("name")
+              .as[String] must beEqualTo("A")
+
   }
 
 }

--- a/src/test/scala/org/mimirdb/profiler/DataProfilerSpec.scala
+++ b/src/test/scala/org/mimirdb/profiler/DataProfilerSpec.scala
@@ -1,0 +1,42 @@
+package org.mimirdb.profiler
+
+import play.api.libs.json.{ Json, JsValue }
+import org.specs2.mutable.Specification
+import org.specs2.specification.BeforeAll
+import org.mimirdb.api.SharedSparkTestInstance
+import org.mimirdb.api.MimirAPI
+import org.mimirdb.util.TimerUtils
+
+class DataProfilerSpec
+  extends Specification
+  with SharedSparkTestInstance
+  with BeforeAll
+{
+  def beforeAll(): Unit = SharedSparkTestInstance.initAPI
+
+  "The Data Profiler" >> {
+
+    val datasetProperties = 
+      TimerUtils.logTime("Run Data Profiler") {
+        DataProfiler(MimirAPI.catalog.get("TEST_R"))
+      }
+
+    println(Json.toJson(datasetProperties))
+
+
+    datasetProperties must haveKey("count")
+    datasetProperties("count").as[Int] must be equalTo(7)
+    
+    datasetProperties must haveKey("columns")    
+    val columnProperties = datasetProperties("columns").as[Seq[Map[String,JsValue]]]
+
+    columnProperties must haveSize(3) 
+    columnProperties.map { _ must haveKey("column") }
+    columnProperties.map { 
+      _("column").as[Map[String,JsValue]].get("name").get.as[String] 
+    } must contain(eachOf("A", "B", "C"))
+    columnProperties.map { 
+      _("column").as[Map[String,JsValue]].get("type").get.as[String] 
+    } must contain("string")
+  }
+}


### PR DESCRIPTION
(re https://github.com/VizierDB/web-ui/issues/236)
(re https://github.com/VizierDB/web-ui/issues/237)

The main feature here is the addition of a minimalistic data profiler.  When enabled with the
RUN-PROFILER experiment, Catalog will run a simple profiler that will generate basic statistics for
each table/view/etc... and serve them up in the `properties` field that gets returned with a Table
query (see DataContainer).

An example profiler result:
```
"properties":{
  "count": 7,
  "columns": [
    {
      "column": {
        "id": 0,
        "name": "A",
        "type": "string"
      },
      "count": 7,
      "distinctValueCount": 3
    },
    {
      "column": {
        "id": 1,
        "name": "B",
        "type": "string"
      },
      "count": 6,
      "distinctValueCount": 3
    },
    {
      "column": {
        "id": 2,
        "name": "C",
        "type": "string"
      },
      "count": 6,
      "distinctValueCount": 4
    }
  ]
}
```

Concretly, this patch adds:
  - Migrating ExperimentalOptions over from MimirClassic to allow basic Feature Flags.
  - Added -X EXPERIMENT-NAME option to configuration to allow enabling experiments
  - ExperimentalOptions now reads a comma-delimited list of experiments to enable from the
    MIMIR_EXPERIMENTS environment variable (if set)
  - Added a simple DataProfiler that gets basic statistics about each table
  - Added the RUN-PROFILER experiment to run the basic profiler when each table is created
  - Separated TimerUtils out into the existing trait and a Stand-alone object
  - Added comments on DataFrameConstructor