### PR TITLE
Materialize views

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ excludeDependencies ++= Seq(
 // Custom Dependencies
 libraryDependencies ++= Seq(
   // Mimir
-  "org.mimirdb"                   %% "mimir-caveats"             % "0.2.1" excludeAll( ExclusionRule("com.fasterxml.jackson.core"), ExclusionRule(organization ="org.apache.httpcomponents", name="httpcore")),
+  "org.mimirdb"                   %% "mimir-caveats"             % "0.2.2" excludeAll( ExclusionRule("com.fasterxml.jackson.core"), ExclusionRule(organization ="org.apache.httpcomponents", name="httpcore")),
   // "org.mimirdb"                   %% "mimir-vizual"              % "0.1-SNAPSHOT",
 
   // API

--- a/src/main/scala/org/mimirdb/api/MimirAPI.scala
+++ b/src/main/scala/org/mimirdb/api/MimirAPI.scala
@@ -304,6 +304,7 @@ class MimirVizierServlet() extends HttpServlet with LazyLogging {
             case "/lens/create"          => processJson[CreateLensRequest](req, output)
             case "/view/create"          => processJson[CreateViewRequest](req, output)
             case "/view/sample"          => processJson[CreateSampleRequest](req, output)
+            case "/view/materialize"     => processJson[MaterializeRequest](req, output)
             case "/vizual/create"        => processJson[VizualRequest](req, output)
             case "/annotations/cell"     => processJson[ExplainCellRequest](req, output)
             case "/annotations/all"      => processJson[ExplainEverythingRequest](req, output)

--- a/src/main/scala/org/mimirdb/api/request/CreateSample.scala
+++ b/src/main/scala/org/mimirdb/api/request/CreateSample.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.functions.{ rand, udf, col }
 import org.apache.spark.sql.types.DataType
 import org.mimirdb.spark.{ SparkPrimitive, Schema }
 import org.mimirdb.api.{ Request, JsonResponse, MimirAPI, CreateResponse }
-import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec }
+import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec, DefaultProvenance }
 
 
 object Sample
@@ -157,7 +157,10 @@ case class CreateSampleRequest (
                   resultName: Option[String],
             /* optional properties */
                   properties: Option[Map[String,JsValue]]
-) extends Request with DataFrameConstructor {
+) extends Request 
+  with DataFrameConstructor
+  with DefaultProvenance
+{
 
   def construct(spark: SparkSession, context: Map[String, () => DataFrame]): DataFrame =
     samplingMode.apply(context(source)(), seed.getOrElse { new Random().nextLong })

--- a/src/main/scala/org/mimirdb/api/request/CreateView.scala
+++ b/src/main/scala/org/mimirdb/api/request/CreateView.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.{ DataFrame, SparkSession, AnalysisException }
 import org.apache.spark.sql.types.StructField
 
 import org.mimirdb.api.{ Request, JsonResponse, MimirAPI, ErrorResponse, FormattedError }
-import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec }
+import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec, DefaultProvenance }
 import org.mimirdb.lenses.AnnotateImplicitHeuristics
 import org.mimirdb.util.ErrorUtils
 import org.mimirdb.spark.{ GetViewDependencies, Schema }
@@ -28,6 +28,7 @@ case class CreateViewRequest (
   extends Request 
   with DataFrameConstructor 
   with LazyLogging
+  with DefaultProvenance
 {
 
   lazy val output = 

--- a/src/main/scala/org/mimirdb/api/request/Materialize.scala
+++ b/src/main/scala/org/mimirdb/api/request/Materialize.scala
@@ -1,0 +1,46 @@
+package org.mimirdb.api.request
+
+import play.api.libs.json._
+
+import org.mimirdb.api.Request
+import org.mimirdb.api.JsonResponse
+import org.mimirdb.api.MimirAPI
+import org.mimirdb.data.MaterializeConstructor
+
+case class MaterializeRequest(
+  table: String,
+  resultName: Option[String]
+)
+  extends Request
+{
+  lazy val output = 
+    resultName.getOrElse {
+      val resultNameBase = table.hashCode()
+      "MATERIALIZED_" + (resultNameBase.toString().replace("-", ""))
+    }
+
+  def handle: MaterializeResponse = 
+  {
+    MimirAPI.catalog.put(
+      table, 
+      MaterializeConstructor(table, MimirAPI.catalog),
+      Set(table)
+    )
+
+    return MaterializeResponse(output)
+  }
+}
+object MaterializeRequest
+{
+  implicit val format: Format[MaterializeRequest] = Json.format
+}
+
+case class MaterializeResponse (
+            /* name of resulting view */
+            name: String
+) extends JsonResponse[MaterializeResponse]
+
+object MaterializeResponse {
+  implicit val format: Format[MaterializeResponse] = Json.format
+}
+

--- a/src/main/scala/org/mimirdb/api/request/Materialize.scala
+++ b/src/main/scala/org/mimirdb/api/request/Materialize.scala
@@ -22,7 +22,7 @@ case class MaterializeRequest(
   def handle: MaterializeResponse = 
   {
     MimirAPI.catalog.put(
-      table, 
+      output, 
       MaterializeConstructor(table, MimirAPI.catalog),
       Set(table)
     )

--- a/src/main/scala/org/mimirdb/data/DataFrameConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/DataFrameConstructor.scala
@@ -16,10 +16,27 @@ trait DataFrameConstructor
    * @param context   Lazy constructors for dependent dataframes, organized by name.  
    * @return          The DataFrame
    *
+   * This function returns a DataFrame intended for computing results, and
+   * may materialize intermediates.  If the intent is to do static analysis,
+   * use provenance().
+   * 
    * When `Catalog.put` is called, one of its parameters is a list of dependencies.  Only dependent
    * tables will be present in the context.
    */
   def construct(spark: SparkSession, context: Map[String,() => DataFrame]): DataFrame
+
+  /**
+   * Return the full provenance of the DataFrame.
+   * 
+   * @param spark     The Spark session in the context of which to create the DataFrame
+   * @param context   Lazy constructors for dependent dataframes, organized by name.  
+   * @return          The DataFrame
+   *
+   * This function returns a DataFrame intended for static analysis, and may
+   * involve more computation than necessary.  If the intent is to compute
+   * values, use construct()
+   */
+  def provenance(spark: SparkSession, context: Map[String, () => DataFrame]): DataFrame
 
   /**
    * The companion object including a deserialization method.
@@ -33,4 +50,11 @@ trait DataFrameConstructor
 trait DataFrameConstructorCodec
 {
   def apply(j: JsValue): DataFrameConstructor
+}
+
+trait DefaultProvenance
+{
+  def construct(spark: SparkSession, context: Map[String, () => DataFrame]): DataFrame
+  def provenance(spark: SparkSession, context: Map[String, () => DataFrame]): DataFrame =
+    construct(spark, context)
 }

--- a/src/main/scala/org/mimirdb/data/InlineConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/InlineConstructor.scala
@@ -13,6 +13,7 @@ case class InlineConstructor(
   schema: Seq[StructField],
   data: Seq[Seq[JsValue]]
 ) extends DataFrameConstructor
+  with DefaultProvenance
 {
   def construct(
     spark: SparkSession, 

--- a/src/main/scala/org/mimirdb/data/LoadConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/LoadConstructor.scala
@@ -27,6 +27,7 @@ case class LoadConstructor(
 ) 
   extends DataFrameConstructor
   with LazyLogging
+  with DefaultProvenance
 {
   def construct(
     spark: SparkSession, 

--- a/src/main/scala/org/mimirdb/data/MaterializeConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/MaterializeConstructor.scala
@@ -1,0 +1,70 @@
+package org.mimirdb.data
+
+import play.api.libs.json._
+import org.apache.spark.sql.{ SparkSession, DataFrame }
+import org.apache.spark.sql.types.{ DataType, StructField }
+import org.mimirdb.rowids.AnnotateWithRowIds
+import org.mimirdb.lenses.AnnotateImplicitHeuristics
+import org.mimirdb.caveats.implicits._
+import org.mimirdb.spark.Schema.fieldFormat
+
+case class MaterializeConstructor(
+  input: String,
+  schema: Seq[StructField], 
+  url: String,
+  format: String, 
+  options: Map[String,String]
+)
+  extends DataFrameConstructor
+{
+
+  def construct(
+    spark: SparkSession, 
+    context: Map[String,() => DataFrame]
+  ): DataFrame = 
+  {
+    var parser = spark.read.format(format)
+    for((option, value) <- options){
+      parser = parser.option(option, value)
+    }
+    var df = parser.load(url)
+
+    println(url)
+
+    // add a silent projection to "strip out" all of the support metadata.
+    df = df.select( schema.map { field => df(field.name) }:_* )
+    
+    return df
+  }
+
+  def provenance(
+    spark: SparkSession, 
+    context: Map[String,() => DataFrame]
+  ): DataFrame = 
+    context(input)()
+}
+
+object MaterializeConstructor
+  extends DataFrameConstructorCodec
+{
+  implicit val format: Format[MaterializeConstructor] = Json.format
+  def apply(v: JsValue): DataFrameConstructor = v.as[MaterializeConstructor]
+
+  val DEFAULT_FORMAT = "parquet"
+
+  def apply(input: String, catalog: Catalog): MaterializeConstructor = 
+  {
+    val format = DEFAULT_FORMAT
+    var df = catalog.get(input)
+    val schema = df.schema.fields.toSeq
+
+    df = AnnotateImplicitHeuristics(df)
+    df = AnnotateWithRowIds(df)
+    df = df.trackCaveats.stripCaveats
+
+    val url = catalog.staging.stage(df, format, Some("materialized"))
+    MaterializeConstructor(input, schema, url, format, Map())
+  }
+
+
+}

--- a/src/main/scala/org/mimirdb/data/RangeConstructor.scala
+++ b/src/main/scala/org/mimirdb/data/RangeConstructor.scala
@@ -11,6 +11,7 @@ case class RangeConstructor(
   step: Long
 )
   extends DataFrameConstructor
+  with DefaultProvenance
   with LazyLogging
 {
   def construct(

--- a/src/main/scala/org/mimirdb/lenses/LensConstructor.scala
+++ b/src/main/scala/org/mimirdb/lenses/LensConstructor.scala
@@ -2,7 +2,7 @@ package org.mimirdb.lenses
 
 import play.api.libs.json._
 import org.apache.spark.sql.{ DataFrame, SparkSession }
-import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec }
+import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec, DefaultProvenance }
 
 case class LensConstructor(
   name: String,
@@ -10,6 +10,7 @@ case class LensConstructor(
   config: JsValue,
   context: String
 ) extends DataFrameConstructor
+  with DefaultProvenance
 {
   def construct(spark: SparkSession, evalContext: Map[String, () => DataFrame]): DataFrame =
     Lenses(name.toLowerCase()).create(evalContext(input)(), config, context)

--- a/src/main/scala/org/mimirdb/vizual/VizualScriptConstructor.scala
+++ b/src/main/scala/org/mimirdb/vizual/VizualScriptConstructor.scala
@@ -2,13 +2,14 @@ package org.mimirdb.vizual
 
 import play.api.libs.json._
 import org.apache.spark.sql.{ DataFrame, SparkSession }
-import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec }
+import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec, DefaultProvenance }
 
 case class VizualScriptConstructor(
   script: Seq[Command],
   input: String
 )
   extends DataFrameConstructor
+  with DefaultProvenance
 {
   def construct(spark: SparkSession, context: Map[String, () => DataFrame]): DataFrame =
     ExecOnSpark(context(input)(), script)

--- a/src/test/scala/org/mimirdb/data/MaterializeSpec.scala
+++ b/src/test/scala/org/mimirdb/data/MaterializeSpec.scala
@@ -1,0 +1,39 @@
+package org.mimirdb.data
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.BeforeAll
+import org.mimirdb.api.{ SharedSparkTestInstance, MimirAPI }
+
+class MaterializeSpec 
+  extends Specification
+  with SharedSparkTestInstance
+  with BeforeAll
+{
+
+  def beforeAll = SharedSparkTestInstance.initAPI
+
+  "Materialize Tables" >> {
+    MimirAPI.catalog.put(
+      "MATERIALIZE_test",
+      MaterializeConstructor("TEST_R", MimirAPI.catalog),
+      Set("TEST_R")
+    )
+
+    val r    = MimirAPI.catalog.get("TEST_R")
+                       .collect()
+                       .map { _.toSeq }
+                       .toSeq
+    val mat  = MimirAPI.catalog.get("MATERIALIZE_test")
+                       .collect()
+                       .map { _.toSeq }
+                       .toSeq
+    val prov = MimirAPI.catalog.getProvenance("MATERIALIZE_test")
+                       .collect()
+                       .map { _.toSeq }
+                       .toSeq
+
+    mat must containTheSameElementsAs(r)
+    prov must containTheSameElementsAs(r)
+  }
+
+}


### PR DESCRIPTION
 Adding support for materializing views.

- Separated two related concerns in DataFrameConstructor: There are now separate methods to construct a dataframe for use in computing results, and one for use in static analysis.  The existing `construct` method takes on the former role (computing results), while the new `provenance` method takes on the latter.
- A helpful trait now addresses the case where provenance == construct.
- Added MaterializeConstructor.  When created, it creates a parquet file with the contents of a dataframe, but preserves the link to the original dataframe.
- Added /view/materialize POST endpoint