### PR TITLE
Force profiler

### DIFF
--- a/src/main/scala/org/mimirdb/api/MimirAPI.scala
+++ b/src/main/scala/org/mimirdb/api/MimirAPI.scala
@@ -341,8 +341,8 @@ class MimirVizierServlet() extends HttpServlet with LazyLogging {
           route match {
             case "/lens"                                    => LensList(Lenses.supportedLenses).write(output)
             case HEAD("blob", TAIL(id))                     => process(GetBlobRequest(id), output)
-            case HEAD("tableInfo", TAIL(id))                => process(SchemaForTableRequest(id), output)
-            case HEAD("tableInfo", HEAD(id, TAIL("schema")))=> process(SchemaForTableRequest(id), output)
+            case HEAD("tableInfo", TAIL(id))                => process(SchemaForTableRequest(id, None), output)
+            case HEAD("tableInfo", HEAD(id, TAIL("schema")))=> process(SchemaForTableRequest(id, None), output)
             case HEAD("tableInfo", HEAD(id, TAIL("size")))  => process(SizeOfTableRequest(id), output)
             case _                                          => fourOhFour(req, output)
           }

--- a/src/main/scala/org/mimirdb/api/request/Query.scala
+++ b/src/main/scala/org/mimirdb/api/request/Query.scala
@@ -67,7 +67,9 @@ case class QueryTableRequest (
             /* starting point to begin returning rows */
                   offset: Option[Long],
             /* include taint in response */
-                  includeUncertainty: Boolean
+                  includeUncertainty: Boolean,
+            /* force profiling */
+                  profile: Option[Boolean]
 ) extends Request {
   def handle = {
     var df = MimirAPI.catalog.get(table)
@@ -82,6 +84,13 @@ case class QueryTableRequest (
 
     // Filter down to the right columns... dropping the sequence number if needed
     df = df.select(columnNames.map { df(_) }:_*)
+
+    val properties = 
+      if(profile.getOrElse(false)){
+        MimirAPI.catalog.profile(table)
+      } else {
+        MimirAPI.catalog.getProperties(table)
+      }
 
     Query(
       df,

--- a/src/main/scala/org/mimirdb/api/request/Query.scala
+++ b/src/main/scala/org/mimirdb/api/request/Query.scala
@@ -122,11 +122,17 @@ object SchemaForQueryRequest {
 
 case class SchemaForTableRequest (
             /* table name */
-                  table: String
+                  table: String,
+            /* force a profiler run */
+                  profile: Option[Boolean]
 ) extends Request {
   def handle = SchemaList(
     Schema(MimirAPI.catalog.get(table)),
-    MimirAPI.catalog.getProperties(table)
+    (if(profile.getOrElse(false)) { 
+      MimirAPI.catalog.profile(table)
+     } else { 
+      MimirAPI.catalog.getProperties(table)
+    })
   )
 }
 

--- a/src/main/scala/org/mimirdb/data/Catalog.scala
+++ b/src/main/scala/org/mimirdb/data/Catalog.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.UnresolvedException
 import org.mimirdb.profiler.DataProfiler
 import org.mimirdb.util.ExperimentalOptions
+import org.mimirdb.util.TaskDeduplicator
 
 /**
  * Lazy data ingest and view management for Mimir
@@ -46,7 +47,8 @@ class Catalog(
   bulkStorageFormat: FileFormat.T = FileFormat.PARQUET,
 ) extends LazyLogging
 {
-  val cache = scala.collection.mutable.Map[String, DataFrame]()
+  val cache = scala.collection.concurrent.TrieMap[String, DataFrame]()
+  val profilingDeduplicator = new TaskDeduplicator[Map[String, JsValue]]()
  
   def this(sqlitedb: String, spark: SparkSession, downloads:String) = 
     this(
@@ -134,7 +136,7 @@ class Catalog(
     dependencies: Set[String], 
     replaceIfExists: Boolean = true,
     properties: Map[String, JsValue] = Map.empty,
-    runProfiler: Boolean = ExperimentalOptions.isEnabled("PROFILER-ON")
+    runProfiler: Boolean = ExperimentalOptions.isEnabled("PROFILE-EVERYTHING")
   )(implicit format: Format[T]): DataFrame = {
     if(!replaceIfExists && views.exists(name)){
       throw new SQLException(s"View $name already exists")
@@ -177,50 +179,64 @@ class Catalog(
 
   def getProperties(name: String): Map[String, JsValue] =
   {
-    val (_, components) = views.get(name).getOrElse {
-      throw new UnresolvedException(
-        UnresolvedRelation(Seq(name)),
-        "lookup"
-      )
+    synchronized {
+      val (_, components) = views.get(name).getOrElse {
+        throw new UnresolvedException(
+          UnresolvedRelation(Seq(name)),
+          "lookup"
+        )
+      }
+      Json.parse(components(3).asInstanceOf[String])
+        .as[Map[String,JsValue]]
     }
-    Json.parse(components(3).asInstanceOf[String])
-      .as[Map[String,JsValue]]
   }
 
   def setProperties(name: String, properties: Map[String, JsValue])
   {
-    val (field, components) = views.get(name).getOrElse {
-      throw new UnresolvedException(
-        UnresolvedRelation(Seq(name)),
-        "lookup"
+    synchronized {
+      val (field, components) = views.get(name).getOrElse {
+        throw new UnresolvedException(
+          UnresolvedRelation(Seq(name)),
+          "lookup"
+        )
+      }
+      views.put(field, 
+        components.patch(3, Seq(Json.toJson(properties).toString), 1)
       )
     }
-    views.put(field, 
-      components.patch(3, Seq(Json.toJson(properties).toString), 1)
-    )
   }
 
   def updateProperties(name: String, properties: Map[String, JsValue])
   {
-    val (field, components) = views.get(name).getOrElse {
-      throw new UnresolvedException(
-        UnresolvedRelation(Seq(name)),
-        "lookup"
+    synchronized {
+      val (field, components) = views.get(name).getOrElse {
+        throw new UnresolvedException(
+          UnresolvedRelation(Seq(name)),
+          "lookup"
+        )
+      }
+      val oldProperties = 
+        Json.parse(components(3).asInstanceOf[String])
+          .as[Map[String,JsValue]]
+      views.put(field, 
+        components.patch(3, Seq(Json.toJson(oldProperties ++ properties).toString), 1)
       )
     }
-    val oldProperties = 
-      Json.parse(components(3).asInstanceOf[String])
-        .as[Map[String,JsValue]]
-    views.put(field, 
-      components.patch(3, Seq(Json.toJson(oldProperties ++ properties).toString), 1)
-    )
   }
 
-  def profile(name: String)
+  def profile(name: String): Map[String,JsValue] =
   {
-    val df = get(name)
-    val properties = DataProfiler(df)
-    updateProperties(name, properties)
+    val properties = getProperties(name)
+    if(properties contains DataProfiler.IS_PROFILED){
+      return properties
+    } else {
+      return profilingDeduplicator.deduplicate(name) {
+        val df = get(name)
+        val properties = DataProfiler(df)
+        updateProperties(name, properties)
+        properties
+      }
+    }
   }
 
 

--- a/src/main/scala/org/mimirdb/profiler/DataProfiler.scala
+++ b/src/main/scala/org/mimirdb/profiler/DataProfiler.scala
@@ -1,11 +1,14 @@
 package org.mimirdb.profiler
 
 import org.apache.spark.sql.DataFrame
-import play.api.libs.json.{ Json, JsValue }
+import play.api.libs.json._
 import org.mimirdb.util.ExperimentalOptions
+import play.api.libs.json.JsArray
 
 object DataProfiler
 {
+  val IS_PROFILED = "is_profiled"
+
   type DatasetProperty = String
   type ColumnProperty = String
   type ColumnName = String
@@ -21,7 +24,9 @@ object DataProfiler
     val (datasetProperties, columnProperties) = 
       profilers.foldLeft(
         (
-          Map[DatasetProperty, JsValue](), 
+          Map[DatasetProperty, JsValue](
+            IS_PROFILED -> JsArray(Seq(JsString("mimir")))
+          ), 
           df.columns.map { _ -> Map[ColumnProperty, JsValue]() }.toMap
         )
       ) { case (accum, profiler) => 

--- a/src/main/scala/org/mimirdb/util/TaskDeduplicator.scala
+++ b/src/main/scala/org/mimirdb/util/TaskDeduplicator.scala
@@ -1,0 +1,69 @@
+package org.mimirdb.util
+
+import scala.concurrent.{ Future, Await }
+import scala.concurrent.duration.Duration
+import scala.collection.concurrent.TrieMap 
+import play.api.libs.json.JsValue
+
+
+/**
+ * A deduplicated task processor.
+ * 
+ * Invoked as :
+ * 
+ *   val ret = 
+ *     processor.deduplicate("My_Task") {
+ *       // code goes here
+ *     }
+ * 
+ * The provided block will be executed and the value returned by the
+ * block will be returned from deduplicate.
+ * 
+ * Guaranteed:
+ * - If another thread calls deduplicate("My_Task") { ... } before 
+ *   the block finishes executing, the second thread will block until
+ *   the first thread is done executing.  
+ * - The return value of all blocked threads will be the value returned
+ *   by the first thread.
+ * 
+ * Not Guaranteed
+ * - If deduplicate(...) is called again after the passed block returns
+ *   the block may be re-executed.
+ */
+class TaskDeduplicator[T]
+{
+  val pending = TrieMap[String, Future[T]]()
+
+  def apply(alias: String, duration: Duration = Duration.Inf)(op: => T): T =
+    deduplicate(alias)(op)
+
+  def deduplicate(alias: String, duration: Duration = Duration.Inf)(op: => T): T = 
+  {
+    val (future, needToDoCleanup) = 
+      // atomically look up the provided alias in the pending
+      // task index.  
+      synchronized {
+        if(pending contains alias){
+          // If present, it means the task is already
+          // being processed.
+          (pending(alias), false)
+        } else {
+          // If not present, we have to create the task
+          val future = Future[T] {
+            val ret = op
+            op
+          }(
+            scala.concurrent.ExecutionContext.global
+          )
+          pending += alias -> future
+          (future, true)
+        }
+      }
+
+    val result = Await.result(future, duration)
+    if(needToDoCleanup){
+      pending -= alias
+    }
+    return result
+  }
+}

--- a/src/test/scala/org/mimirdb/api/PropertiesSpec.scala
+++ b/src/test/scala/org/mimirdb/api/PropertiesSpec.scala
@@ -34,7 +34,7 @@ class PropertiesSpec
       proposedSchema    = None
     ).handle
     val result = 
-      Json.toJson(QueryTableRequest("R_WITH_PROPERTIES", None, None, None, true)
+      Json.toJson(QueryTableRequest("R_WITH_PROPERTIES", None, None, None, true, None)
         .handle)
         .as[DataContainer]
 

--- a/src/test/scala/org/mimirdb/api/request/QuerySpec.scala
+++ b/src/test/scala/org/mimirdb/api/request/QuerySpec.scala
@@ -10,6 +10,7 @@ import org.mimirdb.api.{ SharedSparkTestInstance, MimirAPI }
 import org.mimirdb.caveats.implicits._ 
 import org.mimirdb.lenses.{ Lenses, LensConstructor }
 import org.mimirdb.data.RangeConstructor
+import org.mimirdb.profiler.DataProfiler
 import play.api.libs.json.{ JsString, JsNull }
 import org.mimirdb.spark.{ SparkPrimitive, Schema }
 
@@ -56,14 +57,16 @@ class QuerySpec
     columns: Seq[String] = null,
     limit: Integer = null,
     offset: Integer = null,
-    includeUncertainty: Boolean = false
+    includeUncertainty: Boolean = false,
+    profile: Boolean = false
   )(op: DataContainer => T): T = 
     op( Json.toJson(QueryTableRequest(
           table,
           Option(columns),
           Option(limit).map { _.toInt },
           Option(offset).map { _.toLong },
-          includeUncertainty
+          includeUncertainty,
+          Some(profile)
         ).handle).as[DataContainer] )
 
   "Basic Query Functions" >> {
@@ -235,6 +238,20 @@ class QuerySpec
 
     "Get Table Sizes" >> { 
       SizeOfTableRequest("TEST_R").handle.size must beEqualTo(7)
+    }
+
+    "Profile if needed (and preserve properties)" >> {
+      // If we ask for the data to be profiled, we'd better get a
+      // profile back
+      queryTable("TEST_R", profile = true) { result => 
+        result.properties.keys must contain(DataProfiler.IS_PROFILED)
+      }
+
+      // Once the data is profiled, we'd better keep getting the
+      // same profile back
+      queryTable("TEST_R", profile = false) { result => 
+        result.properties.keys must contain(DataProfiler.IS_PROFILED)
+      }
     }
   }
 

--- a/src/test/scala/org/mimirdb/util/TaskDeduplicatorSpec.scala
+++ b/src/test/scala/org/mimirdb/util/TaskDeduplicatorSpec.scala
@@ -1,0 +1,84 @@
+package org.mimirdb.util
+
+import scala.concurrent.{ Future, Await }
+import scala.util.{Success, Failure}
+import scala.concurrent.duration._
+import java.util.concurrent.atomic.AtomicBoolean
+
+import org.specs2.mutable.Specification
+
+
+class TaskDeduplicatorSpec
+  extends Specification
+{
+  lazy val deduplicate = new TaskDeduplicator[Int]()
+  implicit val ec: scala.concurrent.ExecutionContext = 
+    scala.concurrent.ExecutionContext.global
+
+  "deduplicate tasks" >> {
+
+    // Spin off a thread to process.  If this thread starts
+    // first, we get a 1
+    val xFuture = Future {
+      deduplicate("TEST_1") { 
+        Thread.sleep(2)
+        1
+      }    
+    }
+
+    // Compute TEST_1 again, but this time return a 2.
+    val y = deduplicate("TEST_1") {
+      Thread.sleep(2)
+      2
+    }
+
+    // Recapture the spun-off result
+    val x = Await.result(xFuture, 5.seconds)
+
+    // Depending on which thread "wins" the race, we'll get either
+    // a 1 or a 2.  Either is correct...
+    x must beAnyOf(1, 2)
+
+    // ... but we better get the same result for both threads.
+    y must be equalTo x
+  }
+
+  "not deduplicate distinct aliases" >> {
+
+    // as above, sipn off the x computation into a separate thread
+    val x = Future {
+      deduplicate("TEST_2") { Thread.sleep(1); 1 }
+    }
+    // compute the y value locally
+    val y = deduplicate("TEST_3") { Thread.sleep(1); 2 }
+
+    Await.result(x, 5.seconds) must be equalTo 1
+    y must be equalTo 2
+  }
+
+  "not deduplicate sequential tasks" >> {
+
+    // even though we're using the same alias, we wait for it to finish
+    // before spinning off the next task here.  This isn't a critical 
+    // behavior for the deduplicator, but it's how it works *right now* 
+    // and it would be easy to introduce a bug if this behavior changes.
+    val x = deduplicate("TEST_4") { 1 }
+    val y = deduplicate("TEST_4") { 2 }
+
+    x must be equalTo 1
+    y must be equalTo 2
+  }
+
+  "not return until task side effects are applied" >> {
+    val sideEffect = new AtomicBoolean(false)
+
+    sideEffect.get must beFalse
+    val x = deduplicate("TEST_5") {
+        Thread.sleep(3)
+        sideEffect.set(true)
+        1
+      }
+    sideEffect.get must beTrue
+    x must beEqualTo(1)
+  }
+}


### PR DESCRIPTION
(re: https://github.com/VizierDB/web-ui/issues/275)

- Added a 'profile' option to the /query/table route.  If set, the result is guaranteed to contain profile information.
- Catalog.profile() will now re-use a pre-computed profile if one is available.
- Catalog.profile() will now de-duplicate profiling computations if a call to profile() arrives while a previous profiling run is happening.  If there are two concurrent calls to Catalog.profile() for the same table (and they can't be satisfied from the cache) the profile will still only be computed once (note: Scala Futures are AWESOME).  The same result will go to both callers.
- Added a synchronized {} block to all properties accessors in Catalog and swapped the cache for a concurrent TrieMap.
- DataProfiler now adds a "is_profiled" key to the properties map (alias DataProfiler.IS_PROFILED) currently mapped to an array containing a single keyword "mimir".  The intent is for this to contain a list of profilers that have been applied to the dataset.