### PR TITLE
Cache datasets

### DIFF
--- a/src/main/scala/org/mimirdb/data/DataFrameCache.scala
+++ b/src/main/scala/org/mimirdb/data/DataFrameCache.scala
@@ -1,0 +1,131 @@
+package org.mimirdb.data
+
+import org.apache.spark.sql.{ Row, DataFrame }
+import org.mimirdb.rowids.AnnotateWithSequenceNumber
+import scala.collection.concurrent.TrieMap
+
+/**
+ * A simple LRU cache for dataframes
+ * 
+ * Typical interactions are: 
+ *   DataFrameCache(tableName, df)(start, end)
+ */
+object DataFrameCache
+{
+  /**
+   * The number of rows in a buffer page
+   */
+  val BUFFER_PAGE = {
+    val str = System.getenv("DATAFRAME_CACHE_PAGE_ROWS")
+    if(str.equals("")) { 10000 } else { str.toInt }
+  }
+  /**
+   * The number of pages cached before we start evictions
+   */
+  val BUFFER_SIZE = {
+    val str = System.getenv("DATAFRAME_CACHE_PAGE_SIZE")
+    if(str.equals("")) { 100 } else { str.toInt }
+  }
+
+  /**
+   * The actual cache
+   */
+  private val cache = TrieMap[String, CachedDataFrame]()
+
+  /**
+   * The user-facing lookup function
+   */
+  def apply(table: String, df: DataFrame): CachedDataFrame =
+  {
+    cache.getOrElseUpdate(table, { new CachedDataFrame(df) } )
+  }
+
+  /**
+   * Align start/end to page boundaries
+   *
+   * TODO: Enable some sort of prefetching, by expanding the range 
+   * if start is close to end?
+   */
+  def alignRange(start: Int, end: Int): (Int, Int) =
+  {
+    (
+      start - (start % BUFFER_PAGE), 
+
+      end + (if(end % BUFFER_PAGE == 0){ 0 }
+             else { (BUFFER_PAGE - (end % BUFFER_PAGE)) })
+    )
+  }
+
+  /**
+   * Check if the buffer is too big and release cache entries if so.
+   *
+   * The `target` parameter is guaranteed to remain in the cache
+   * after this is invoked
+   */
+  def updatePageCount(target: CachedDataFrame)
+  {
+    // Tally up the number of pages allocated in the cache
+    val pages = cache.values.map { _.pages }.sum
+
+    // If we need to free...
+    if(pages > BUFFER_SIZE){
+      var freed = 0
+      // Simple LRU: Iterate over the elements in order of last access
+      for((table, entry) <- cache.toSeq.sortBy { -_._2.lastAccessed }){
+        // Keep freeing until we've freed enough pages.
+        if(pages - freed > BUFFER_SIZE){ 
+          // Make sure that we don't free the one thing that we're updating
+          if(entry != target){
+            // Remove the table from the cache
+            cache.remove(table)
+            // And register the pages that we've freed
+            freed += entry.pages
+          }
+        }
+      }
+    }
+    // In the unlikely event that we were asked to buffer more than the buffer
+    // size, it'll still be in the cache... but the buffer size should be big
+    // enough to prevent that.
+  }
+
+  def countPages(start: Int, end: Int): Int =
+  {
+    ((end - start) / BUFFER_PAGE) + 
+      (if((end-start) % BUFFER_PAGE > 0) { 1 } else { 0 })
+  }
+}
+
+
+class CachedDataFrame(df: DataFrame)
+{
+  var lastAccessed = System.currentTimeMillis()
+  var bufferStart = 0
+  var buffer: Array[Row] = Array()
+  
+  def bufferEnd = bufferStart + buffer.size
+
+  def apply(start: Int, end: Int): Array[Row] = 
+  {
+    if(start < bufferStart || end >= bufferEnd){ 
+      rebuffer(start, end)
+    }
+    lastAccessed = System.currentTimeMillis()
+    buffer.slice(start - bufferStart, end - bufferEnd)
+  }
+
+  def rebuffer(start: Int, end: Int)
+  {
+    val (targetStart, targetEnd) = DataFrameCache.alignRange(start, end)
+    DataFrameCache.updatePageCount(this)
+    buffer = df.filter(
+                  (df(AnnotateWithSequenceNumber.ATTRIBUTE) >= targetStart)
+                    and
+                  (df(AnnotateWithSequenceNumber.ATTRIBUTE) < targetEnd)
+                )
+               .collect()
+    bufferStart = targetStart
+  }
+
+  def pages = DataFrameCache.countPages(bufferStart, bufferEnd)
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,6 +16,8 @@
   <!--++++++++++++++++++++++++  Data  ++++++++++++++++++++++++++-->
   <logger name="org.mimirdb.data.JDBCMetadataBackend"           level="ERROR" />
   <logger name="org.mimirdb.data.Catalog"                       level="ERROR" />
+  <logger name="org.mimirdb.data.DataFrameCache$"               level="INFO" />
+  <logger name="org.mimirdb.data.CachedDataFrame"               level="INFO" />
 
   <!--++++++++++++++++++++++++  Vizual  ++++++++++++++++++++++++++-->
   <logger name="org.mimirdb.vizual.ExecOnSpark"                 level="ERROR" />

--- a/src/test/scala/org/mimirdb/data/CatalogSpec.scala
+++ b/src/test/scala/org/mimirdb/data/CatalogSpec.scala
@@ -1,11 +1,11 @@
 package org.mimirdb.data
 
 import org.specs2.mutable.Specification
+import org.specs2.specification.BeforeAll
 import org.mimirdb.api.SharedSparkTestInstance
 import org.mimirdb.api.request.DataContainer
 import org.mimirdb.api.request.Query
 import play.api.libs.json.JsValue
-import org.specs2.specification.BeforeAll
 
 class CatalogSpec 
   extends Specification

--- a/src/test/scala/org/mimirdb/data/DataFrameCacheSpec.scala
+++ b/src/test/scala/org/mimirdb/data/DataFrameCacheSpec.scala
@@ -1,0 +1,65 @@
+package org.mimirdb.data
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.BeforeAll
+import org.mimirdb.api.{ MimirAPI, SharedSparkTestInstance }
+import org.mimirdb.util.TimerUtils
+
+class DataFrameCacheSpec
+  extends Specification
+  with SharedSparkTestInstance
+{
+
+  "Improve dataframe performance on small tables" >> {
+    val test_r = spark.read
+                      .option("header", "true")
+                      .csv("test_data/r.csv")
+    val test_r_cache = 
+      DataFrameCache("TEST_R_PERFORMANCE") { test_r }
+
+    val (coldRows, coldTime) = 
+      TimerUtils.time { test_r.collect().map { r => (r.getAs[Int](0), r.getAs[Int](1), r.getAs[Int](2))} }
+    println(s"Cold Access ($test_r): ${coldTime/1000000000.0} s")
+    val (hotRows, hotTime) = 
+      TimerUtils.time { test_r.collect().map { r => (r.getAs[Int](0), r.getAs[Int](1), r.getAs[Int](2))} }
+    println(s"Hot Access ($test_r): ${hotTime/1000000000.0} s")
+    hotRows must beEqualTo(coldRows)
+    hotTime should beLessThan(coldTime)
+
+    // warm up the cache:
+    val (coldCacheRows, coldCacheTime) = 
+      TimerUtils.time { test_r_cache(0, coldRows.size).map { r => (r.getAs[Int](0), r.getAs[Int](1), r.getAs[Int](2))} }
+
+    println(s"Cold Cache Access ($test_r): ${coldCacheTime/1000000000.0} s")
+    coldCacheRows must beEqualTo(coldRows)
+
+    val (hotCachedRows, hotCacheTime) = 
+      TimerUtils.time { test_r_cache(0, coldRows.size).map { r => (r.getAs[Int](0), r.getAs[Int](1), r.getAs[Int](2))} }
+    println(s"Hot Cache Access ($test_r): ${hotCacheTime/1000000000.0} s")
+
+    hotCachedRows must beEqualTo(coldRows)
+    hotCacheTime should beLessThan(hotTime)
+  }
+
+  "Handle paging correctly" >> {
+    val PAGE = DataFrameCache.BUFFER_PAGE
+    val seq = DataFrameCache("SEQ_PERFORMANCE"){
+                spark.range(PAGE * 10).toDF
+              }
+
+    def getRows(start: Long, end: Long) = {
+      val rows = seq(start, end) 
+      rows must haveSize((end - start).toInt)
+      rows.map { _.getAs[Long](0) }.toSeq
+    }
+    getRows(0, 10) must beEqualTo(0 until 10)
+    getRows(0, PAGE) must beEqualTo(0 until PAGE.toInt)
+
+    TimerUtils.time { getRows(0, PAGE) }
+              ._2 must beLessThan(10000000l) // 10 ms
+
+
+    getRows(PAGE, PAGE*2) must beEqualTo(PAGE until (PAGE*2))
+    getRows(PAGE/2, (PAGE*3)/2) must beEqualTo((PAGE/2) until ((PAGE*3)/2))
+  }
+}


### PR DESCRIPTION
Adding transparent support for caching in Mimir (a step towards https://github.com/VizierDB/web-ui/issues/61)

Specifically, with the `CACHE-TABLES` experiment enabled, queries for tables (the `/query/table` endpoint) will go through a simple LRU cache.
- The `DATAFRAME_CACHE_PAGE_ROWS` environment variable (default 10k) controls the number of rows per cache 'page',
- The `DATAFRAME_CACHE_PAGE_SIZE` environment variable controls the number of 'page's available.

The cache is likely in dire need of some tuning, but should work reasonably well for small (<5k row) datasets.
