### PR TITLE
LoadDataset loading now uses castWithCaveat

### DIFF
--- a/src/main/scala/org/mimirdb/spark/Schema.scala
+++ b/src/main/scala/org/mimirdb/spark/Schema.scala
@@ -30,6 +30,8 @@ object Schema {
   def encodeType(t: DataType): String =
     t match {
       case ArrayType(element, _) => s"array:${encodeType(element)}"
+      case DoubleType => "real"
+      case IntegerType => "int"
       case _ => t.typeName
     }
 


### PR DESCRIPTION
- LoadDataset now uses castWithCaveat to coerce types into
  the proposed (or in the case of CSV files, detected) schema.
  This way, user-overrides of the schema still produce caveats.
- Also making mimir-provided types more consistent with what
  Vizier expects: 'real' for DoubleType, and 'int' for IntegerType.