### PR TITLE
Add dataframe endpoint.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/ArrowProxy.scala
+++ b/src/main/scala/org/apache/spark/sql/ArrowProxy.scala
@@ -18,21 +18,23 @@ object ArrowProxy {
   
   val allocator = new RootAllocator(Integer.MAX_VALUE);
   
-  def writeToMemoryFile(file:String, df:DataFrame) = {
-    val schema = ArrowUtils.toArrowSchema(df.schema, "EST")
+  def writeToMemoryFile(file:String, df:DataFrame): (Int, String) = {
     val arrowOut = toArrow(df)
+    /*val bytesWritten = 0;
+    val schema = ArrowUtils.toArrowSchema(df.schema, "EST")
     val rafile = new RandomAccessFile(file, "rw")
     val out = rafile.getChannel()
-                                        //.map(FileChannel.MapMode.READ_WRITE, 0, 2048);
-    val bytesWritten = 0;
+    //.map(FileChannel.MapMode.READ_WRITE, 0, 2048);
     val root = VectorSchemaRoot.create(schema, allocator)
-  
+    rafile.write(arrowOut)
+    println(s"toArrow: ${arrowOut.map(el => s"${el.getClass} -> $el" ).mkString("\n", "\n", "\n")}")
     val writer = new ArrowStreamWriter(root, null, out)
     writer.start();
     writer.writeBatch();
     writer.end();
     val totalBytesWritten = writer.bytesWritten();
-    println(totalBytesWritten)
+    println(totalBytesWritten)*/
+    (arrowOut(0).asInstanceOf[Int], arrowOut(1).asInstanceOf[String])
   }
   
 }

--- a/src/main/scala/org/mimirdb/api/MimirAPI.scala
+++ b/src/main/scala/org/mimirdb/api/MimirAPI.scala
@@ -172,6 +172,7 @@ class MimirVizierServlet() extends HttpServlet with LazyLogging {
       if(text.size > len){ text.substring(0, len-3)+"..." } else { text }
 
 
+
     def process(
       handler: Request, 
       output: HttpServletResponse, 
@@ -309,6 +310,7 @@ class MimirVizierServlet() extends HttpServlet with LazyLogging {
             case "/annotations/cell"     => processJson[ExplainCellRequest](req, output)
             case "/annotations/all"      => processJson[ExplainEverythingRequest](req, output)
             case "/query/data"           => processJson[QueryMimirRequest](req, output)
+            case "/query/dataframe"      => processJson[QueryDataFrameRequest](req, output)
             case "/query/table"          => processJson[QueryTableRequest](req, output)
             case "/schema"               => processJson[SchemaForQueryRequest](req, output)
             case "/tableInfo"            => processJson[SchemaForTableRequest](req, output)

--- a/src/main/scala/org/mimirdb/spark/InitSpark.scala
+++ b/src/main/scala/org/mimirdb/spark/InitSpark.scala
@@ -19,6 +19,7 @@ object InitSpark
       //.config("spark.eventLog.longForm.enabled", "true")
       .config("spark.serializer", classOf[KryoSerializer].getName)
       .config("spark.kryo.registrator", classOf[GeoSparkVizKryoRegistrator].getName)
+      .config("spark.kryoserializer.buffer.max", "2000m")
       .master("local[*]")
       .getOrCreate()
   }


### PR DESCRIPTION
Adds an endpoint to MimirAPI that takes a query and collects a dataframe for read access from python using apache arrow.  This is the first step towards: https://github.com/VizierDB/web-ui/issues/91 and https://github.com/VizierDB/web-ui/issues/251 but also useful standing on it's own.  There is an associated PR in web-api-async: https://github.com/VizierDB/web-api-async/pull/107