### PR TITLE
Possible support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ excludeDependencies ++= Seq(
 // Custom Dependencies
 libraryDependencies ++= Seq(
   // Mimir
-  "org.mimirdb"                   %% "mimir-caveats"             % "0.2.3" excludeAll( ExclusionRule("com.fasterxml.jackson.core"), ExclusionRule(organization ="org.apache.httpcomponents", name="httpcore")),
+  "org.mimirdb"                   %% "mimir-caveats"             % "0.2.4" excludeAll( ExclusionRule("com.fasterxml.jackson.core"), ExclusionRule(organization ="org.apache.httpcomponents", name="httpcore")),
   // "org.mimirdb"                   %% "mimir-vizual"              % "0.1-SNAPSHOT",
 
   // API

--- a/src/main/scala/org/mimirdb/api/request/CreateView.scala
+++ b/src/main/scala/org/mimirdb/api/request/CreateView.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.{ DataFrame, SparkSession, AnalysisException }
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.catalyst.expressions.Expression
 
+import org.mimirdb.caveats.lifting.ResolveLifts
 import org.mimirdb.api.{ Request, JsonResponse, MimirAPI, ErrorResponse, FormattedError }
 import org.mimirdb.data.{ DataFrameConstructor, DataFrameConstructorCodec, DefaultProvenance }
 import org.mimirdb.lenses.AnnotateImplicitHeuristics
@@ -68,6 +69,7 @@ case class CreateViewRequest (
                               .toMap
               )
     df = AnnotateImplicitHeuristics(df)
+    df = ResolveLifts(df)
     return df 
   }
 

--- a/src/main/scala/org/mimirdb/api/request/Query.scala
+++ b/src/main/scala/org/mimirdb/api/request/Query.scala
@@ -336,6 +336,9 @@ object Query
     /////// Decorate any potentially erroneous heuristics
     df = AnnotateImplicitHeuristics(df)
 
+    /////// ResolvePossible
+    df = ResolveLifts(df)
+
 
     logger.trace(s"----------- RAW-QUERY-----------\nSCHEMA:{ ${Schema(df).mkString(", ")} }\n${df.queryExecution.explainString(SelectedExplainMode)}")
 
@@ -343,9 +346,6 @@ object Query
     df = AnnotateWithRowIds(df)
 
     logger.trace(s"----------- AFTER-ROWID -----------\n${df.queryExecution.explainString(SelectedExplainMode)}")
-
-    /////// ResolvePossible
-    df = ResolveLifts(df)
 
 
     /////// If requested, add a __CAVEATS attribute

--- a/src/main/scala/org/mimirdb/api/request/Query.scala
+++ b/src/main/scala/org/mimirdb/api/request/Query.scala
@@ -23,6 +23,7 @@ import org.mimirdb.rowids.AnnotateWithSequenceNumber
 import org.mimirdb.spark.InjectedSparkSQL
 import org.mimirdb.util.ExperimentalOptions
 import org.apache.spark.sql.ArrowProxy
+import org.mimirdb.caveats.lifting.ResolveLifts
 
 case class QueryMimirRequest (
             /* input for query */
@@ -335,12 +336,17 @@ object Query
     /////// Decorate any potentially erroneous heuristics
     df = AnnotateImplicitHeuristics(df)
 
+
     logger.trace(s"----------- RAW-QUERY-----------\nSCHEMA:{ ${Schema(df).mkString(", ")} }\n${df.queryExecution.explainString(SelectedExplainMode)}")
 
     /////// Add a __MIMIR_ROWID attribute
     df = AnnotateWithRowIds(df)
 
     logger.trace(s"----------- AFTER-ROWID -----------\n${df.queryExecution.explainString(SelectedExplainMode)}")
+
+    /////// ResolvePossible
+    df = ResolveLifts(df)
+
 
     /////// If requested, add a __CAVEATS attribute
     /////// Either way, after we track the caveats, we no longer need the

--- a/src/test/scala/org/mimirdb/api/request/QuerySpec.scala
+++ b/src/test/scala/org/mimirdb/api/request/QuerySpec.scala
@@ -255,4 +255,17 @@ class QuerySpec
     }
   }
 
+  "Query possible answers" >> {
+    query("""
+      SELECT * FROM (
+        SELECT CAVEATIF(A, A IS NULL, "FOO") AS A,
+               CAVEATIF(B, B IS NULL, "FOO") AS B,
+               CAVEATIF(C, C IS NULL, "FOO") AS C
+        FROM TEST_R
+      ) TEST_R 
+      WHERE POSSIBLE(B = 2) AND C = 1
+    """) { result => 
+      result.data.size must beEqualTo(2)
+    }
+  }
 }

--- a/src/test/scala/org/mimirdb/data/SafelyLoadFunkyData.scala
+++ b/src/test/scala/org/mimirdb/data/SafelyLoadFunkyData.scala
@@ -66,27 +66,27 @@ class SafelyLoadFunkyData
   // }
 
   "Data with funky unicode - csv edition" >> {
-    skipped("https://github.com/UBOdin/mimir-api/issues/9")
-  //   val df = MimirAPI.catalog.put(
-  //     "CURE_SOURCE_CSV",
-  //     LoadConstructor(
-  //       "test_data/cureSource.csv",
-  //       "csv",
-  //       Catalog.defaultLoadOptions("csv", true)
-  //     ),
-  //     Set.empty,
-  //     true,
-  //     Map.empty
-  //   )
+    // skipped("https://github.com/UBOdin/mimir-api/issues/9")
+    val df = MimirAPI.catalog.put(
+      "CURE_SOURCE_CSV",
+      LoadConstructor(
+        "test_data/cureSource.csv",
+        "csv",
+        Catalog.defaultLoadOptions("csv", true)
+      ),
+      Set.empty,
+      true,
+      Map.empty
+    )
 
-  //   df.stripCaveats.explain()
-  //   // df.count() must be equalTo(8910l)
-  //   val ret = 
-  //     df.select(col("date"))
-  //       .collect()
-  //       .map { _.getString(0) }
-  //   ret.size must beEqualTo(8911)
-  //   ret.toSeq must not(contain(beNull))
+    df.stripCaveats.explain()
+    // df.count() must be equalTo(8910l)
+    val ret = 
+      df.select(col("date"))
+        .collect()
+        .map { _.getString(0) }
+    ret.size must beEqualTo(8910)
+    ret.toSeq must not(contain(beNull))
   }
 
 }


### PR DESCRIPTION
This is a relatively small PR to bring in Caveats 0.2.4 with (limited) support for possible answers.  With this PR, the following query:

```
SELECT * FROM TEST_R 
WHERE POSSIBLE(B = 2) AND C = 1
```

Will return rows where C =1 and where it is conceivable that B = 2 (i.e., B = 2 or B != 2, but has a caveat).